### PR TITLE
Set From property in mail message

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/EmailNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/EmailNotificationService.java
@@ -98,8 +98,10 @@ public class EmailNotificationService implements NotificationService {
     private MimeMessage createMimeMessage(Email email) throws AddressException, MessagingException {
 
     	MimeMessage mail = mailSender.createMimeMessage();
+	InternetAddress senderAddress = new InternetAddress(email.getFrom());
         mail.addRecipient(RecipientType.TO, new InternetAddress(email.getTo()));
-        mail.setSender(new InternetAddress(email.getFrom()));
+	mail.setSender(senderAddress);
+	mail.setFrom(senderAddress);
         mail.setText(email.getMessage());
         mail.setSubject(email.getSubject());
         mail.addHeader("Content-Type", "text/html; charset=UTF-8");


### PR DESCRIPTION
Some email servers do not use the Sender property in the mail header to derive who the "from" address should be, and will either spam emails, or send emails "from" and "unknown sender" as a result. 
so adding the From property fixes this for emails servers which use this.
