### PR TITLE
Adding PagerDuty Notifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+                <biz.neustar.version>1.0-beta-2</biz.neustar.version>
 		<ch.qos.logback.version>1.0.6</ch.qos.logback.version>
 		<com.github.rest-driver.version>1.1.24</com.github.rest-driver.version>
         <com.google.guava.version>12.0</com.google.guava.version>
@@ -306,6 +307,11 @@
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-web</artifactId>
 				<version>${org.springframework.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>biz.neustar</groupId>
+				<artifactId>pagerduty</artifactId>
+				<version>${biz.neustar.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/seyren-core/pom.xml
+++ b/seyren-core/pom.xml
@@ -89,6 +89,10 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>biz.neustar</groupId>
+			<artifactId>pagerduty</artifactId>
+		</dependency>		
 	</dependencies>
 
 	<build>

--- a/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
@@ -15,6 +15,6 @@ package com.seyren.core.domain;
 
 public enum SubscriptionType {
 	
-	EMAIL, SMS 
+	EMAIL, SMS, PAGERDUTY  
 
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/PagerDutyNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/PagerDutyNotificationService.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.notification;
+
+import biz.neustar.pagerduty.InternalException;
+import biz.neustar.pagerduty.InvalidEventException;
+import biz.neustar.pagerduty.PagerDutyClient;
+import biz.neustar.pagerduty.model.EventResponse;
+import com.seyren.core.domain.Alert;
+import com.seyren.core.domain.AlertType;
+import com.seyren.core.domain.Check;
+import com.seyren.core.domain.Subscription;
+import com.seyren.core.exception.NotificationFailedException;
+import com.seyren.core.util.config.SeyrenConfig;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+public class PagerDutyNotificationService implements NotificationService {
+
+    private final SeyrenConfig seyrenConfig;
+    private PagerDutyClient client;
+    
+    @Override
+    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+                
+        client = new PagerDutyClient(seyrenConfig.getPagerDutyDomain(), "username", "password");
+        try {        
+            Map details = AddDetailsToNotification(check, alerts);
+            EventResponse response = null;        
+            if (check.getState()== AlertType.ERROR)
+                response = client.trigger(subscription.getTarget(), "Check " + check.getName() + " has exceeded its threshold.  " + seyrenConfig.getBaseUrl() + "/#/checks/" + check.getId(), "MonitoringAlerts_" + check.getId(), details);
+            else
+                response = client.resolve(subscription.getTarget(), "Check " + check.getName() + " has been resolved. " + seyrenConfig.getBaseUrl() + "/#/checks/" + check.getId(), "MonitoringAlerts_" + check.getId(), details);
+            } 
+        catch (Exception e) {
+            throw new NotificationFailedException("Failed to send notification to PagerDuty", e);
+        }         
+    }
+    
+    @Inject
+    public PagerDutyNotificationService(SeyrenConfig seyrenConfig) {
+        this.seyrenConfig = seyrenConfig;
+    }
+    
+    private Map AddDetailsToNotification(Check check, List<Alert> alerts) {
+        Map details = new HashMap();
+        details.put("CHECK", check);
+        details.put("ALERTS", alerts);
+        details.put("SEYREN_URL", seyrenConfig.getBaseUrl());
+        return details;
+    }
+
+    @Override
+    public void sendStatusEmail(List<Check> checks) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 package com.seyren.core.service.schedule;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,13 +29,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import com.google.common.base.Optional;
-import com.seyren.core.domain.Alert;
-import com.seyren.core.domain.AlertType;
-import com.seyren.core.domain.Check;
-import com.seyren.core.domain.Subscription;
+import com.seyren.core.domain.*;
 import com.seyren.core.service.checker.TargetChecker;
 import com.seyren.core.service.checker.ValueChecker;
+import com.seyren.core.service.notification.EmailNotificationService;
 import com.seyren.core.service.notification.NotificationService;
+import com.seyren.core.service.notification.PagerDutyNotificationService;
 import com.seyren.core.store.AlertsStore;
 import com.seyren.core.store.ChecksStore;
 
@@ -47,17 +45,17 @@ public class CheckScheduler {
 
 	private final ChecksStore checksStore;
 	private final AlertsStore alertsStore;
-	private final NotificationService notificationService;
+	private final List<NotificationService> notificationServices;
 	private final TargetChecker targetChecker;
 	private final ValueChecker valueChecker;
 	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(8);
 
 	@Inject
-	public CheckScheduler(ChecksStore checksStore, AlertsStore alertsStore, NotificationService notificationService, TargetChecker targetChecker,
+	public CheckScheduler(ChecksStore checksStore, AlertsStore alertsStore, List<NotificationService> notificationServices, TargetChecker targetChecker,
 	        ValueChecker valueChecker) {
 		this.checksStore = checksStore;
 		this.alertsStore = alertsStore;
-        this.notificationService = notificationService;
+             this.notificationServices = notificationServices;
 		this.targetChecker = targetChecker;
 		this.valueChecker = valueChecker;
 	}
@@ -165,9 +163,14 @@ public class CheckScheduler {
                     }
                     
                     try {
-                        notificationService.sendNotification(check, subscription, interestingAlerts);
+                        for (NotificationService n: notificationServices) {
+                            if (n.getClass().toString().toLowerCase().contains(subscription.getType().toString().toLowerCase()) == true) {
+                                LOGGER.debug("Notifying via " + n.getClass().toString().toLowerCase() + " to " + subscription.getType().toString());
+                                n.sendNotification(check, subscription, interestingAlerts);
+                            }
+                        }                     
                     } catch (Exception e) {
-                        LOGGER.warn("Notifying " + subscription.getTarget() + " failed", e);
+                        LOGGER.warn("Notifying " + subscription.getTarget() + " by " + subscription.getType() + " failed", e);
                     }
                 }
                 

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -23,11 +23,13 @@ public class SeyrenConfig {
 
 	private final GraphiteConfig graphite;
 	private final String baseUrl;
+        private final String pagerDutyDomain;
 
 	@Inject
 	public SeyrenConfig(GraphiteConfig graphite) {
 		this.graphite = graphite;
 		this.baseUrl = stripEnd(environmentOrDefault("SEYREN_URL", "http://localhost:8080/seyren"), "/");
+		this.pagerDutyDomain = environmentOrDefault("PAGERDUTY_DOMAIN", "mydomain");
 	}
 	
 	public GraphiteConfig getGraphite() {
@@ -36,6 +38,10 @@ public class SeyrenConfig {
 
     public String getBaseUrl() {
         return baseUrl;
+    }
+
+    public String getPagerDutyDomain() {
+        return pagerDutyDomain;
     }
     
     private static String environmentOrDefault(String propertyName, String defaultValue) {

--- a/seyren-web/src/main/webapp/html/check.html
+++ b/seyren-web/src/main/webapp/html/check.html
@@ -173,6 +173,7 @@
                         <div class="controls">
                             <select id="newsubscription.type" class="input-medium" name="newsubscription.type">
                                 <option value="EMAIL">Email</option>
+								<option value="PAGERDUTY">PagerDuty</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
this makes use of biz.neustar PagerDuty work (https://github.com/webmetrics/pagerduty-java).

Its not perftect, but that's due to the model rather than the work i've added, for some reason the last change introduced to the main repo added a new method to the NotificationService.java interface all other notifications are supposedly meant to implement, question why you would have a sendemailstatus method you want to override in all other types of notification services?? but for now, just going to get in the changes, also need to look at the whole structure as the current model doesn't really work for anything more than one notification type of email, unless my Java can be improved and we can somehow infer at runtime which notification type to fire off based on the notification type of the subscription being checked.
any improvements/comments are welcome.
Will need to update the readme to include a note about adding a PAGERDUTY_DOMAIN env variable if the use should want to use this.
