### PR TITLE
Added HipChat Notifications to Seyren

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ open http://localhost:8080/seyren
 * `GRAPHITE_USERNAME` - The Http Basic auth username for the graphite server. Default: ``
 * `GRAPHITE_PASSWORD` - The Http Basic auth password for the graphite server. Default: ``
 * `MONGO_URL` - The mongo connection string. Default: `mongodb://localhost:27017/seyren`
+* `HIPCHAT_AUTH_TOKEN` - The hipchat api auth token. Default: ``
+* `HIPCHAT_USER_NAME` - The username that messages will be sent from to a hipchat room. Default: `Seyren Alert`
 * `PAGERDUTY_DOMAIN` - The PagerDuty domain to be notified. Default: ``
 * `SEYREN_URL` - The location of your seyren instance. Default: `http://localhost:8080/seyren`
 * `SEYREN_FROM_EMAIL` - The from email address for sending out notifications. Default: `alert@seyren`

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<com.github.rest-driver.version>1.1.24</com.github.rest-driver.version>
         <com.google.guava.version>12.0</com.google.guava.version>
 		<com.yammer.metrics.version>2.1.2</com.yammer.metrics.version>
+        <commons-httpclient.version>3.1</commons-httpclient.version>
 		<commons.io.version>2.3</commons.io.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<javax.inject.version>1</javax.inject.version>
@@ -181,6 +182,11 @@
 				<groupId>com.yammer.metrics</groupId>
 				<artifactId>metrics-web</artifactId>
 				<version>${com.yammer.metrics.version}</version>
+			</dependency>
+            <dependency>
+				<groupId>commons-httpclient</groupId>
+				<artifactId>commons-httpclient</artifactId>
+				<version>${commons-httpclient.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/seyren-core/pom.xml
+++ b/seyren-core/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>	  
+			<type>jar</type>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -92,7 +97,7 @@
 		<dependency>
 			<groupId>biz.neustar</groupId>
 			<artifactId>pagerduty</artifactId>
-		</dependency>		
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
@@ -15,6 +15,6 @@ package com.seyren.core.domain;
 
 public enum SubscriptionType {
 	
-	EMAIL, PAGERDUTY  
+	EMAIL, PAGERDUTY, HIPCHAT
 
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/HipChatNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/HipChatNotificationService.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.notification;
+
+import com.seyren.core.domain.*;
+import com.seyren.core.exception.NotificationFailedException;
+import com.seyren.core.util.config.SeyrenConfig;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.slf4j.LoggerFactory;
+
+@Named
+public class HipChatNotificationService implements NotificationService {
+
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(HipChatNotificationService.class);
+    private final SeyrenConfig seyrenConfig;
+
+    private String host = "api.hipchat.com";     
+    private String from;
+
+    @Inject
+    public HipChatNotificationService(SeyrenConfig seyrenConfig) {
+        this.seyrenConfig = seyrenConfig;
+    }
+
+    @Override
+    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+        String token = seyrenConfig.getHipChatAuthToken();
+        String from = seyrenConfig.getHipChatUserName();
+        String[] roomIds = subscription.getTarget().split(",");
+        try {          
+            if (check.getState() == AlertType.ERROR) {
+                String message = "Check <a href="+ seyrenConfig.getBaseUrl() + "/#/checks/" + check.getId() + ">" + check.getName() + "</a> has exceeded its error threshold value. Please investigate.";
+                SendMessage(message, MessageColor.RED, roomIds, from, token, true);
+            } else if (check.getState() == AlertType.OK) {
+                String message = "Check <a href="+ seyrenConfig.getBaseUrl() + "/#/checks/" + check.getId() + ">" + check.getName() + "</a> is back up.";
+                SendMessage(message, MessageColor.GREEN, roomIds, from, token, true);
+            } else {
+                LOGGER.warn("Did not send notification to HipChat for check in state: " + check.getState());
+            }
+        } catch (Exception e) {
+            throw new NotificationFailedException("Failed to send notification to HipChat", e);
+        }
+    }      
+        
+    public void SendMessage(String message, MessageColor color, String[] roomIds, String from, String authToken, boolean notify) {
+        for (String roomId : roomIds) {
+            LOGGER.info("Posting: " + from + " to " + roomId + ": " + message + " " + color);
+            HttpClient client = new HttpClient();
+            String url = "https://" + host + "/v1/rooms/message?auth_token=" + authToken;
+            PostMethod post = new PostMethod(url);
+
+            try {
+                post.addParameter("from", from);
+                post.addParameter("room_id", roomId);
+                post.addParameter("message", message);
+                post.addParameter("color", color.name().toLowerCase());
+                if (notify)
+                {
+                    post.addParameter("notify", "1");
+                }
+                post.getParams().setContentCharset("UTF-8");
+                client.executeMethod(post);
+            } catch (Exception e) {
+                LOGGER.warn("Error posting to HipChat", e);
+            } finally {
+                post.releaseConnection();
+            }
+        }
+    }
+
+    @Override
+    public boolean canHandle(SubscriptionType subscriptionType) {
+        return subscriptionType == SubscriptionType.HIPCHAT;
+    }
+    
+    public enum MessageColor
+    {
+        YELLOW, RED, GREEN, PURPLE, RANDOM;
+    }
+}
+
+

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -25,6 +25,8 @@ public class SeyrenConfig {
 	private final String baseUrl;
 	private final String fromEmail;
 	private final String pagerDutyDomain;
+	private final String hipChatAuthToken;
+	private final String hipChatUserName;
 
 	@Inject
 	public SeyrenConfig(GraphiteConfig graphite) {
@@ -32,6 +34,8 @@ public class SeyrenConfig {
 		this.baseUrl = stripEnd(environmentOrDefault("SEYREN_URL", "http://localhost:8080/seyren"), "/");
 		this.fromEmail = environmentOrDefault("SEYREN_FROM_EMAIL", "alert@seyren");
 		this.pagerDutyDomain = environmentOrDefault("PAGERDUTY_DOMAIN", "");
+		this.hipChatAuthToken = environmentOrDefault("HIPCHAT_AUTH_TOKEN", "");
+		this.hipChatUserName = environmentOrDefault("HIPCHAT_USER_NAME", "Seyren Alert");
 	}
 	
 	public GraphiteConfig getGraphite() {
@@ -48,6 +52,14 @@ public class SeyrenConfig {
     
     public String getPagerDutyDomain() {
         return pagerDutyDomain;
+    }
+    
+    public String getHipChatAuthToken() {
+        return hipChatAuthToken;
+    }
+	
+    public String getHipChatUserName() {
+        return hipChatUserName;
     }
     
     private static String environmentOrDefault(String propertyName, String defaultValue) {

--- a/seyren-web/src/main/webapp/html/check.html
+++ b/seyren-web/src/main/webapp/html/check.html
@@ -173,7 +173,8 @@
                         <div class="controls">
                             <select id="newsubscription.type" class="input-medium" name="newsubscription.type">
                                 <option value="EMAIL">Email</option>
-								<option value="PAGERDUTY">PagerDuty</option>
+                                <option value="HIPCHAT">HipChat</option>
+                                <option value="PAGERDUTY">PagerDuty</option>                                
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
Uses hipchat api (https://www.hipchat.com/docs/api)  

Works much like PagerDutyAlerts, when we get an Error we send a message to hipchat room with red colour, when we get an OK, we send a message saying the check is back up with green colour.
Have skipped warn thresholds in yellow colour, I had it in, but too it out as when you have checks which flap between error and ok a lot, the chatrooms become to noisy, although if you want that back in its easy enough to add it.
The subscription target is the hipchat room id, you can pass in multiple room id's separated by a comma i.e, 0001,0002,0003 to send the same message to different rooms.
