### PR TITLE
Add support for SMTP over TLS

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/util/email/SeyrenMailSender.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/email/SeyrenMailSender.java
@@ -46,10 +46,17 @@ public class SeyrenMailSender extends JavaMailSenderImpl {
         setUsername(username);
         setPassword(password);
         
+        Properties props = new Properties();
         if(username != "" && password != "") {
-	        Properties props = new Properties();
-	        props.setProperty("mail.smtp.auth", "true");
-	        setJavaMailProperties(props);
+            props.setProperty("mail.smtp.auth", "true");
+        }
+
+        if(getPort() == 587) {
+            props.put("mail.smtp.starttls.enable", "true");
+        }
+
+        if(props.size() > 0) {
+            setJavaMailProperties(props);
         }
         
         setProtocol(protocol);


### PR DESCRIPTION
My environment requires all outbound SMTP over TLS so I added support to Seyren. This is the same as the GMail settings so I felt like it would be more generally useful in the main Seryren code base.
