### PR TITLE
Seyren webapp shutdown stuck on CheckScheduler.executor's non terminated thread

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
@@ -202,7 +202,7 @@ public class CheckScheduler {
 
     @PreDestroy
     public void preDestroy() throws InterruptedException {
-        // executor.shutdown();
-        // executor.awaitTermination(500, TimeUnit.MILLISECONDS);
+        executor.shutdown();
+        executor.awaitTermination(500, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
Seyren webapp shutdown stuck on CheckScheduler.executor's non terminated thread

Fix description:
1. Add `@PreDestroy` hook to shutdown `CheckScheduler.executor`
2. Make `CheckScheduler.executor` threads `daemon`
