### PR TITLE
Root Seyren URL with only "slash" returns 404 when Seyren run on Tomcat 6.0 and 7.0

### DIFF
--- a/seyren-web/src/main/webapp/WEB-INF/web.xml
+++ b/seyren-web/src/main/webapp/WEB-INF/web.xml
@@ -27,11 +27,6 @@
     </servlet>
 
     <servlet-mapping>
-        <servlet-name>default</servlet-name>
-        <url-pattern>/*</url-pattern>
-    </servlet-mapping>
-    
-    <servlet-mapping>
         <servlet-name>Resteasy</servlet-name>
         <url-pattern>/api/*</url-pattern>
     </servlet-mapping>


### PR DESCRIPTION
Removing the declaration of "default" servlet works with Tomcat 6.0, Tomcat 7.0 both and without Jetty (via jetty-runner).
