### PR TITLE
Add System Property configuration in addition to System Environment variables

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/util/config/GraphiteConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/GraphiteConfig.java
@@ -78,11 +78,15 @@ public class GraphiteConfig {
     }
     
     private static String environmentOrDefault(String propertyName, String defaultValue) {
-        String value = System.getenv(propertyName);
-        if (isEmpty(value)) {
-            return defaultValue;
+        String value = System.getProperty(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
         }
-        return value;
+        value = System.getenv(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
+        }
+        return defaultValue;
     }
     
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -69,11 +69,15 @@ public class SeyrenConfig {
     }
     
     private static String environmentOrDefault(String propertyName, String defaultValue) {
-        String value = System.getenv(propertyName);
-        if (isEmpty(value)) {
-            return defaultValue;
+        String value = System.getProperty(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
         }
-        return value;
+        value = System.getenv(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
+        }
+        return defaultValue;
     }
     
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/email/SeyrenMailSender.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/email/SeyrenMailSender.java
@@ -74,13 +74,17 @@ public class SeyrenMailSender extends JavaMailSenderImpl {
         setPort(port);
         return this;
     }
-    
+
     private static String environmentOrDefault(String propertyName, String defaultValue) {
-        String value = System.getenv(propertyName);
-        if (isEmpty(value)) {
-            return defaultValue;
+        String value = System.getProperty(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
         }
-        return value;
+        value = System.getenv(propertyName);
+        if (isNotEmpty(value)) {
+            return value;
+        }
+        return defaultValue;
     }
-    
+
 }


### PR DESCRIPTION
PaaS like CloudBees use System Properties (and not environment variables) to inject environment specific properties.

Add support for system-properties based configuration in addition to the existing environment-variables mechanism.
