### PR TITLE
Issue 85: need to access the Graphite base URL through config.graphiteUrl, not config.graphite.baseUrl

### DIFF
--- a/seyren-web/src/main/webapp/js/check-controller.js
+++ b/seyren-web/src/main/webapp/js/check-controller.js
@@ -213,7 +213,7 @@ CheckController.prototype = {
     
     getBaseGraphUrl : function(minutes) {
         if (this.config && this.check) {
-            var result = this.config.graphite.baseUrl + '/render/?';
+            var result = this.config.graphiteUrl + '/render/?';
             result += 'target=' + this.check.target;
             result += '&from=' + minutes + 'Minutes';
             result += '&target=alias(dashed(color(constantLine(' + this.check.warn + '),"yellow")),"warn level")';

--- a/seyren-web/src/main/webapp/js/checks-controller.js
+++ b/seyren-web/src/main/webapp/js/checks-controller.js
@@ -87,7 +87,7 @@ ChecksController.prototype = {
     
     getSmallGraphUrl : function() {
         if (this.config && this.newcheck.target) {
-            var result = this.config.graphite.baseUrl + '/render/?';
+            var result = this.config.graphiteUrl + '/render/?';
             result += 'target=' + this.newcheck.target;
             result += '&target=alias(dashed(color(constantLine(' + this.newcheck.warn + '),"yellow")),"warn level")';
             result += '&target=alias(dashed(color(constantLine(' + this.newcheck.error + '),"red")),"error level")';


### PR DESCRIPTION
Mark,

Issue 85 is due to the refactoring done in Issue 82, and specifically we need to access the Graphite base URL through config.graphiteUrl, not config.graphite.baseUrl.

Otherwise the Graphite graphs will not work due to:

Error: this.config.graphite is undefined
CheckController.prototype.getBaseGraphUrl@GRAPHITE_URL/js/check-controller.js:216

Thanks,
Olivier.
