### PR TITLE
For security reasons, do not expose all SeyrenConfig fields

### DIFF
--- a/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ConfigAT.java
+++ b/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ConfigAT.java
@@ -16,7 +16,7 @@ package com.seyren.acceptancetests;
 import static com.github.restdriver.serverdriver.Matchers.*;
 import static com.github.restdriver.serverdriver.RestServerDriver.*;
 import static com.seyren.acceptancetests.util.SeyrenDriver.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import org.junit.Test;
@@ -31,42 +31,15 @@ public class ConfigAT {
         assertThat(response, hasStatusCode(200));
         
         // Base
+        assertThat(response.asJson().size(), is(6));
         assertThat(response.asJson(), hasJsonPath("$.baseUrl", is("http://localhost:8080/seyren")));
-        assertThat(response.asJson(), hasJsonPath("$.mongoUrl", is("mongodb://localhost:27017/seyren")));
-        
+
         // Graphite
         assertThat(response.asJson(), hasJsonPath("$.graphiteUrl", is("http://localhost:80")));
-        assertThat(response.asJson(), hasJsonPath("$.graphiteUsername", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.graphitePassword", is("")));
         assertThat(response.asJson(), hasJsonPath("$.graphiteScheme", is("http")));
         assertThat(response.asJson(), hasJsonPath("$.graphiteHost", is("localhost:80")));
         assertThat(response.asJson(), hasJsonPath("$.graphitePath", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.graphiteKeyStore", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.graphiteKeyStorePassword", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.graphiteTrustStore", is("")));
-
-        // SMTP
-        assertThat(response.asJson(), hasJsonPath("$.smtpFrom", is("alert@seyren")));
-        assertThat(response.asJson(), hasJsonPath("$.smtpUsername", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.smtpPassword", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.smtpHost", is("localhost")));
-        assertThat(response.asJson(), hasJsonPath("$.smtpProtocol", is("smtp")));
-        assertThat(response.asJson(), hasJsonPath("$.smtpPort", is(25)));
-        
-        // HipChat
-        assertThat(response.asJson(), hasJsonPath("$.hipChatAuthToken", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.hipChatUsername", is("Seyren Alert")));
-        
-        // PagerDuty
-        assertThat(response.asJson(), hasJsonPath("$.pagerDutyDomain", is("")));
-        
-        // Hubot
-        assertThat(response.asJson(), hasJsonPath("$.hubotUrl", is("")));
-
-        // Flowdock
-        assertThat(response.asJson(), hasJsonPath("$.flowdockExternalUsername", is("Seyren")));
-        assertThat(response.asJson(), hasJsonPath("$.flowdockTags", is("")));
-        assertThat(response.asJson(), hasJsonPath("$.flowdockEmojis", is("")));
+        assertThat(response.asJson(), hasJsonPath("$.graphiteSSLPort", is(80)));
     }
-    
+
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -13,12 +13,15 @@
  */
 package com.seyren.core.util.config;
 
-import static org.apache.commons.lang.StringUtils.*;
-
 import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Named;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.stripEnd;
 
 @Named
 public class SeyrenConfig {
@@ -94,71 +97,88 @@ public class SeyrenConfig {
 	public String getBaseUrl() {
         return baseUrl;
     }
-    
+
+    @JsonIgnore
     public String getMongoUrl() {
 		return mongoUrl;
 	}
-    
+
+    @JsonIgnore
     public String getPagerDutyDomain() {
         return pagerDutyDomain;
     }
-    
+
+    @JsonIgnore
     public String getPagerDutyToken() {
         return pagerDutyToken;
     }
 
+    @JsonIgnore
     public String getPagerDutyUsername() {
         return pagerDutyUsername;
     }
 
+    @JsonIgnore
     public String getPagerDutyPassword() {
         return pagerDutyPassword;
     }
 
+    @JsonIgnore
     public String getHipChatAuthToken() {
         return hipChatAuthToken;
     }
-    
+
+    @JsonIgnore
     public String getHipChatUsername() {
         return hipChatUsername;
     }
-    
+
+    @JsonIgnore
     public String getHubotUrl() {
         return hubotUrl;
     }
 
+    @JsonIgnore
     public String getFlowdockExternalUsername() {
         return flowdockExternalUsername;
     }
 
+    @JsonIgnore
     public String getFlowdockTags() {
         return flowdockTags;
     }
 
+    @JsonIgnore
     public String getFlowdockEmojis() {
         return flowdockEmojis;
     }
 
+    @JsonIgnore
     public String getSmtpFrom() {
         return smtpFrom;
     }
-    
+
+    @JsonIgnore
     public String getSmtpUsername() {
 		return smtpUsername;
 	}
 
+    @JsonIgnore
 	public String getSmtpPassword() {
 		return smtpPassword;
 	}
 
+    @JsonIgnore
 	public String getSmtpHost() {
 		return smtpHost;
 	}
 
+    @JsonIgnore
 	public String getSmtpProtocol() {
 		return smtpProtocol;
 	}
 
+    @JsonIgnore
 	public Integer getSmtpPort() {
 		return smtpPort;
 	}
@@ -166,15 +186,17 @@ public class SeyrenConfig {
 	public String getGraphiteUrl() {
 		return graphiteUrl;
 	}
-	
+
+    @JsonIgnore
 	public String getGraphiteUsername() {
 		return graphiteUsername;
 	}
-	
+
+    @JsonIgnore
 	public String getGraphitePassword() {
 		return graphitePassword;
 	}
-	
+
 	public String getGraphiteScheme() {
 		return splitBaseUrl(graphiteUrl)[0];
 	}
@@ -191,14 +213,17 @@ public class SeyrenConfig {
 		return splitBaseUrl(graphiteUrl)[3];
 	}
 
+    @JsonIgnore
     public String getGraphiteKeyStore() {
         return graphiteKeyStore;
     }
 
+    @JsonIgnore
     public String getGraphiteKeyStorePassword() {
         return graphiteKeyStorePassword;
     }
 
+    @JsonIgnore
     public String getGraphiteTrustStore() {
         return graphiteTrustStore;
     }

--- a/seyren-core/src/test/java/com/seyren/core/service/checker/GraphiteTargetCheckerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/checker/GraphiteTargetCheckerTest.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,12 +37,17 @@ public class GraphiteTargetCheckerTest {
     public ClientDriverRule clientDriver = new ClientDriverRule();
     
     private GraphiteTargetChecker checker;
-    
+
     @Before
     public void before() {
         checker = new GraphiteTargetChecker(seyrenConfig(clientDriver.getBaseUrl()));
     }
-    
+
+    @After
+    public void after() {
+        System.clearProperty("GRAPHITE_URL");
+    }
+
     @Test
     public void singleValidTargetIsPresent() throws Exception {
         String response = "[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[0.06, 1337453460]]}]";

--- a/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.util.config;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SeyrenConfigTest {
+    @Test
+    public void test_default_seyren_config() {
+        SeyrenConfig config = new SeyrenConfig();
+
+        // Base
+        assertThat(config.getBaseUrl(), is("http://localhost:8080/seyren"));
+        assertThat(config.getMongoUrl(), is("mongodb://localhost:27017/seyren"));
+
+        // Graphite
+        assertThat(config.getGraphiteUrl(), is("http://localhost:80"));
+        assertThat(config.getGraphiteUsername(), is(""));
+        assertThat(config.getGraphitePassword(), is(""));
+        assertThat(config.getGraphiteScheme(), is("http"));
+        assertThat(config.getGraphiteHost(), is("localhost:80"));
+        assertThat(config.getGraphitePath(), is(""));
+        assertThat(config.getGraphiteKeyStore(), is(""));
+        assertThat(config.getGraphiteKeyStorePassword(), is(""));
+        assertThat(config.getGraphiteTrustStore(), is(""));
+
+        // SMTP
+        assertThat(config.getSmtpFrom(), is("alert@seyren"));
+        assertThat(config.getSmtpUsername(), is(""));
+        assertThat(config.getSmtpPassword(), is(""));
+        assertThat(config.getSmtpHost(), is("localhost"));
+        assertThat(config.getSmtpProtocol(), is("smtp"));
+        assertThat(config.getSmtpPort(), is(25));
+
+        // HipChat
+        assertThat(config.getHipChatAuthToken(), is(""));
+        assertThat(config.getHipChatUsername(), is("Seyren Alert"));
+
+        // PagerDuty
+        assertThat(config.getPagerDutyDomain(), is(""));
+
+        // Hubot
+        assertThat(config.getHubotUrl(), is(""));
+
+        // Flowdock
+        assertThat(config.getFlowdockExternalUsername(), is("Seyren"));
+        assertThat(config.getFlowdockTags(), is(""));
+        assertThat(config.getFlowdockEmojis(), is(""));
+    }
+}


### PR DESCRIPTION
- Filter SeyrenConfig to not expose internal configuration client
- Add SeyrenConfigTest to test internal object as opposite of ConfigAT which tests json
