### PR TITLE
Reordered 'Stand alone' build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Seyren ([/ˈsaɪ.rʌn/](http://en.wikipedia.org/wiki/Wikipedia:IPA_for_English#K
 ###Stand alone
 
 ```
-export GRAPHITE_URL=http://graphite.foohost.com:80
 mvn clean package
+export GRAPHITE_URL=http://graphite.foohost.com:80
 java -jar seyren-web/target/dependency/jetty-runner.jar --path /seyren seyren-web/target/*.war
 open http://localhost:8080/seyren
 ```


### PR DESCRIPTION
After `SeyrenConfigTest.java` was introduced all seyren specific environment variables must be empty to prevent breaking the `mvn clean package` command (i.e. the SeyrenConfigTest tests fail when enviroment vars are set).

Therefore the `mvn clean package` should be run _before_ any environment vars are set.
I've updated the README's `Stand alone` section to reflect this necessity.
