### PR TITLE
Add Webhook Notifications to Seyren

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/SubscriptionType.java
@@ -15,6 +15,6 @@ package com.seyren.core.domain;
 
 public enum SubscriptionType {
     
-    EMAIL, PAGERDUTY, HIPCHAT, HUBOT, FLOWDOCK
+    EMAIL, PAGERDUTY, HIPCHAT, HUBOT, FLOWDOCK, WEBHOOK
     
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/WebhookNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/WebhookNotificationService.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.notification;
+
+
+import com.seyren.core.domain.Alert;
+import com.seyren.core.domain.Check;
+import com.seyren.core.domain.Subscription;
+import com.seyren.core.domain.SubscriptionType;
+import com.seyren.core.exception.NotificationFailedException;
+import com.seyren.core.util.config.SeyrenConfig;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+public class WebhookNotificationService implements NotificationService {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookNotificationService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    
+    private final SeyrenConfig seyrenConfig;    
+    
+    @Inject
+    public WebhookNotificationService(SeyrenConfig seyrenConfig) {
+        this.seyrenConfig = seyrenConfig;
+    }
+    
+    @Override
+    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+        
+        String webHookUrl = StringUtils.trimToNull(subscription.getTarget());
+        
+        if (webHookUrl == null) {
+            LOGGER.warn("WebHook URL needs to be set before sending notifications to webhook");
+            return;
+        }
+        Map<String, Object> body = new HashMap<String, Object>();
+        body.put("seyrenUrl", seyrenConfig.getBaseUrl());
+        body.put("check", check);
+        body.put("subscription", subscription);
+        body.put("alerts", alerts);        
+        body.put("preview", getPreviewImage(check)); 
+        
+        HttpClient client = new DefaultHttpClient();
+        
+        HttpPost post = new HttpPost(subscription.getTarget());
+        try {
+            HttpEntity entity = new StringEntity(MAPPER.writeValueAsString(body), ContentType.APPLICATION_JSON);
+            post.setEntity(entity);
+            HttpResponse response = client.execute(post);
+            HttpEntity responseEntity = response.getEntity();
+            if(responseEntity!=null) {
+                LOGGER.info("Response : {} ", EntityUtils.toString(responseEntity));
+            }
+        } catch (Exception e) {
+            throw new NotificationFailedException("Failed to send notification to WebHook", e);           
+        } finally {
+            post.releaseConnection();
+        }
+    }
+    
+    @Override
+    public boolean canHandle(SubscriptionType subscriptionType) {
+        return subscriptionType == SubscriptionType.WEBHOOK;
+    }
+   
+    private String getPreviewImage(Check check)
+    {
+        return "<br /><img src=" + seyrenConfig.getGraphiteUrl() + "/render/?target=" + check.getTarget() + getTimeFromUntilString(new Date()) +
+                         "&target=alias(dashed(color(constantLine(" + check.getWarn().toString() + "),%22yellow%22)),%22warn%20level%22)&target=alias(dashed(color(constantLine(" + check.getError().toString() 
+                        + "),%22red%22)),%22error%20level%22)&width=500&height=225></img>"; 
+                
+    }
+       
+    private String getTimeFromUntilString(Date date)
+    {        
+        Calendar cal = Calendar.getInstance();
+        SimpleDateFormat format = new SimpleDateFormat("HH:mm_yyyyMMdd");
+        cal.setTime(date);
+        cal.add(Calendar.HOUR, -1);
+        String from = format.format(cal.getTime());
+        cal.add(Calendar.HOUR, 1);
+        String until = format.format(cal.getTime());
+
+        return "&from=" + until.toString() + "&until=" + from.toString();   
+    }
+    
+}

--- a/seyren-core/src/test/java/com/seyren/core/service/notification/WebhookNotificationServiceTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/notification/WebhookNotificationServiceTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.notification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import static com.github.restdriver.Matchers.hasJsonPath;
+import com.github.restdriver.clientdriver.ClientDriverRequest.Method;
+import com.github.restdriver.clientdriver.ClientDriverRule;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import com.github.restdriver.clientdriver.capture.BodyCapture;
+import com.github.restdriver.clientdriver.capture.JsonBodyCapture;
+import com.seyren.core.domain.*;
+import com.seyren.core.util.config.SeyrenConfig;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+
+public class WebhookNotificationServiceTest {
+    
+    private SeyrenConfig mockSeyrenConfig;
+    private NotificationService service;
+    
+    @Rule
+    public ClientDriverRule clientDriver = new ClientDriverRule();
+    
+    @Before
+    public void before() {
+        mockSeyrenConfig = mock(SeyrenConfig.class);
+        service = new WebhookNotificationService(mockSeyrenConfig);
+    }
+    
+    @Test
+    public void notifcationServiceCanOnlyHandleWebHookSubscription() {
+        assertThat(service.canHandle(SubscriptionType.WEBHOOK), is(true));
+        for (SubscriptionType type : SubscriptionType.values()) {
+            if (type == SubscriptionType.WEBHOOK) {
+                continue;
+            }
+            assertThat(service.canHandle(type), is(false));
+        }
+    }
+    
+    @Test
+    public void checkingOutTheHappyPath() {
+        
+        String seyrenUrl = clientDriver.getBaseUrl() + "/seyren";
+        
+        when(mockSeyrenConfig.getGraphiteUrl()).thenReturn(clientDriver.getBaseUrl() + "/graphite");
+        when(mockSeyrenConfig.getBaseUrl()).thenReturn(seyrenUrl);
+        
+        Check check = new Check()
+                .withEnabled(true)
+                .withName("check-name")
+                .withTarget("statsd.metric.name")
+                .withState(AlertType.ERROR)
+                .withWarn(BigDecimal.ONE)
+                .withError(BigDecimal.TEN);
+        
+        Subscription subscription = new Subscription()
+                .withType(SubscriptionType.WEBHOOK)
+                .withTarget(clientDriver.getBaseUrl() + "/myWebHook/thatdoesstuff");
+        
+        Alert alert = new Alert()
+                .withTarget("the.target.name")
+                .withValue(BigDecimal.valueOf(12))
+                .withWarn(BigDecimal.valueOf(5))
+                .withError(BigDecimal.valueOf(10))
+                .withFromType(AlertType.WARN)
+                .withToType(AlertType.ERROR);
+        
+        List<Alert> alerts = Arrays.asList(alert);
+        
+        BodyCapture<JsonNode> bodyCapture = new JsonBodyCapture();
+        
+        clientDriver.addExpectation(
+                onRequestTo("/myWebHook/thatdoesstuff")
+                        .withMethod(Method.POST)
+                        .capturingBodyIn(bodyCapture),
+                giveResponse("success", "text/plain"));
+        
+        service.sendNotification(check, subscription, alerts);
+        
+        JsonNode node = bodyCapture.getContent();
+        
+        
+        assertThat(node, hasJsonPath("$.seyrenUrl", is(seyrenUrl)));
+        assertThat(node, hasJsonPath("$.check.name", is("check-name")));
+        assertThat(node, hasJsonPath("$.check.state", is("ERROR")));
+        assertThat(node, hasJsonPath("$.alerts", hasSize(1)));
+        assertThat(node, hasJsonPath("$.alerts[0].target", is("the.target.name")));
+        assertThat(node, hasJsonPath("$.alerts[0].value", is(12)));
+        assertThat(node, hasJsonPath("$.alerts[0].warn", is(5)));
+        assertThat(node, hasJsonPath("$.alerts[0].error", is(10)));
+        assertThat(node, hasJsonPath("$.alerts[0].fromType", is("WARN")));
+        assertThat(node, hasJsonPath("$.alerts[0].toType", is("ERROR")));
+        assertThat(node, hasJsonPath("$.preview", startsWith("<br />")));
+        assertThat(node, hasJsonPath("$.preview", containsString(check.getTarget())));
+        
+        verify(mockSeyrenConfig).getGraphiteUrl();
+        verify(mockSeyrenConfig).getBaseUrl();
+        
+    }
+    
+}

--- a/seyren-web/src/main/webapp/html/modal-partial-subscription.html
+++ b/seyren-web/src/main/webapp/html/modal-partial-subscription.html
@@ -22,6 +22,7 @@
                             <option value="PAGERDUTY">PagerDuty</option>
                             <option value="HUBOT">Hubot</option>
                             <option value="FLOWDOCK">Flowdock</option>
+                            <option value="WEBHOOK">Webhook</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Have added webhook notifications to seyren, allows http posts of json payload to be sent to a given url as a subscription target as mentioned in #131, did this a couple months ago but was sidetracked on other things, but is really useful - as is taking images of graphites graphs when the alert happens so i've kept this in, but happy if its moved to its own place in a seperate commit, as im sure some of the other notification types could benefit from having it as well (i use it in hipchat notifications myself as well).
