### PR TITLE
Added support for a new GraphiteInstance entity in partial support of is...

### DIFF
--- a/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/GraphiteInstancesAT.java
+++ b/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/GraphiteInstancesAT.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.acceptancetests;
+
+import static com.github.restdriver.serverdriver.Matchers.*;
+import static com.github.restdriver.serverdriver.RestServerDriver.*;
+import static com.seyren.acceptancetests.util.SeyrenDriver.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+
+import com.github.restdriver.serverdriver.http.response.Response;
+
+/**
+ * @author Willie Wheeler (willie.wheeler@gmail.com)
+ */
+public class GraphiteInstancesAT {
+    
+    @Test
+    public void testGetGraphiteInstancesReturnsOk() {
+        Response response = get(graphiteInstances());
+        assertThat(response, hasStatusCode(200));
+        assertThat(response.asJson(), hasJsonPath("$.values", hasSize(0)));
+    }
+    
+    @Test
+    public void testGetGraphiteInstancesReturnsResultsOk() {
+        Response createResponse = createGraphiteInstance("{ }");
+        Response response = get(graphiteInstances());
+        assertThat(response, hasStatusCode(200));
+        assertThat(response.asJson(), hasJsonPath("$.values", hasSize(1)));
+        deleteLocation(createResponse.getHeader("Location").getValue());
+    }
+    
+    @Test
+    public void testCreateGraphiteInstanceReturnsCreated() {
+        Response response = createGraphiteInstance("{ }");
+        assertThat(response, hasStatusCode(201));
+        deleteLocation(response.getHeader("Location").getValue());
+    }
+    
+    @Test
+    public void testCreateGraphiteInstanceWithName() {
+        Response response = createGraphiteInstance("{ \"name\" : \"Graphite - Lab\" }");
+        assertThat(response, hasStatusCode(201));
+        String location = response.getHeader("Location").getValue();
+        assertThat(get(location).asJson(), hasJsonPath("$.name", is("Graphite - Lab")));
+        deleteLocation(location);
+    }
+    
+    private Response createGraphiteInstance(String body) {
+        Response response = post(graphiteInstances(), body(body, "application/json"));
+        assertThat(response, hasStatusCode(201));
+        assertThat(response, hasHeader("Location"));
+        return response;
+    }
+    
+    private void deleteLocation(String location) {
+        assertThat(get(location), hasStatusCode(200));
+        delete(location);
+        assertThat(get(location), hasStatusCode(404));
+    }
+}

--- a/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/util/SeyrenDriver.java
+++ b/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/util/SeyrenDriver.java
@@ -50,6 +50,10 @@ public final class SeyrenDriver {
         return new Url(checkLocation.getValue()).withPath("/subscriptions");
     }
     
+    public static Url graphiteInstances() {
+        return baseUri().withPath("graphite-instances");
+    }
+    
     private static Url baseUri() {
         return new Url("http://" + host() + ":" + port() + "/" + contextRoot()).withPath("api");
     }

--- a/seyren-api/src/main/java/com/seyren/api/bean/GraphiteInstancesBean.java
+++ b/seyren-api/src/main/java/com/seyren/api/bean/GraphiteInstancesBean.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.api.bean;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.seyren.api.jaxrs.GraphiteInstancesResource;
+import com.seyren.core.domain.GraphiteInstance;
+import com.seyren.core.domain.SeyrenResponse;
+import com.seyren.core.store.GraphiteInstancesStore;
+
+/**
+ * Bean implementing the REST API's Graphite instance endpoints.
+ * 
+ * @author Willie Wheeler (willie.wheeler@gmail.com)
+ */
+@Named
+public class GraphiteInstancesBean implements GraphiteInstancesResource {
+    private GraphiteInstancesStore graphiteInstancesStore;
+    
+    @Inject
+    public GraphiteInstancesBean(GraphiteInstancesStore graphiteInstancesStore) {
+        this.graphiteInstancesStore = graphiteInstancesStore;
+    }
+
+    @Override
+    public Response getGraphiteInstances() {
+        SeyrenResponse<GraphiteInstance> graphiteInstances = graphiteInstancesStore.getGraphiteInstances();
+        return Response.ok(graphiteInstances).build();
+    }
+
+    @Override
+    public Response createGraphiteInstance(GraphiteInstance graphiteInstance) {
+        GraphiteInstance stored = graphiteInstancesStore.createGraphiteInstance(graphiteInstance);
+        return Response.created(uri(stored.getId())).build();
+    }
+
+    @Override
+    public Response getGraphiteInstance(String graphiteInstanceId) {
+        GraphiteInstance graphiteInstance = graphiteInstancesStore.getGraphiteInstance(graphiteInstanceId);
+        if (graphiteInstance == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+        return Response.ok(graphiteInstance).build();
+    }
+
+    @Override
+    public Response updateGraphiteInstance(String graphiteInstanceId, GraphiteInstance graphiteInstance) {
+        GraphiteInstance stored = graphiteInstancesStore.getGraphiteInstance(graphiteInstanceId);
+        if (stored == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+        stored = graphiteInstancesStore.updateGraphiteInstance(graphiteInstance);
+        return Response.ok(stored).build();
+    }
+
+    @Override
+    public Response deleteGraphiteInstance(String graphiteInstanceId) {
+        graphiteInstancesStore.deleteGraphiteInstance(graphiteInstanceId);
+        return Response.noContent().build();
+    }
+    
+    private URI uri(String graphiteInstanceId) {
+        try {
+            return new URI("graphite-instances/" + graphiteInstanceId);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+}

--- a/seyren-api/src/main/java/com/seyren/api/jaxrs/GraphiteInstancesResource.java
+++ b/seyren-api/src/main/java/com/seyren/api/jaxrs/GraphiteInstancesResource.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.api.jaxrs;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.seyren.core.domain.GraphiteInstance;
+
+/**
+ * Resource definition for the Graphite instance endpoints.
+ * 
+ * @author Willie Wheeler (willie.wheeler@gmail.com)
+ */
+@Path("/")
+public interface GraphiteInstancesResource {
+    
+    @GET
+    @Path("/graphite-instances")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getGraphiteInstances();
+    
+    @POST
+    @Path("/graphite-instances")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response createGraphiteInstance(GraphiteInstance graphiteInstance);
+    
+    @GET
+    @Path("/graphite-instances/{graphiteInstanceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getGraphiteInstance(@PathParam("graphiteInstanceId") String graphiteInstanceId);
+    
+    @PUT
+    @Path("/graphite-instances/{graphiteInstanceId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response updateGraphiteInstance(
+            @PathParam("graphiteInstanceId") String graphiteInstanceId,
+            GraphiteInstance graphiteInstance);
+    
+    @DELETE
+    @Path("/graphite-instances/{graphiteInstanceId}")
+    Response deleteGraphiteInstance(@PathParam("graphiteInstanceId") String graphiteInstanceId);
+}

--- a/seyren-core/src/main/java/com/seyren/core/domain/GraphiteInstance.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/GraphiteInstance.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * <p>
+ * Represents a Graphite instance.
+ * </p>
+ * <p>
+ * The intent is to provide a way to consume multiple Graphite instances from a single Seyren instance.
+ * </p>
+ * 
+ * @author Willie Wheeler (willie.wheeler@gmail.com)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GraphiteInstance {
+    private String id;
+    private String name;
+    private String baseUrl;
+    private String username;
+    private String password;
+    private String keyStore;
+    private String keyStorePassword;
+    private String trustStore;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    public GraphiteInstance withId(String id) {
+        setId(id);
+        return this;
+    }
+    
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public GraphiteInstance withName(String name) {
+        setName(name);
+        return this;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+    
+    public GraphiteInstance withBaseUrl(String baseUrl) {
+        setBaseUrl(baseUrl);
+        return this;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public GraphiteInstance withUsername(String username) {
+        setUsername(username);
+        return this;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    
+    public GraphiteInstance withPassword(String password) {
+        setPassword(password);
+        return this;
+    }
+
+    public String getKeyStore() {
+        return keyStore;
+    }
+
+    public void setKeyStore(String keyStore) {
+        this.keyStore = keyStore;
+    }
+    
+    public GraphiteInstance withKeyStore(String keyStore) {
+        setKeyStore(keyStore);
+        return this;
+    }
+
+    public String getKeyStorePassword() {
+        return keyStorePassword;
+    }
+    
+    public void setKeyStorePassword(String keyStorePassword) {
+        this.keyStorePassword = keyStorePassword;
+    }
+    
+    public GraphiteInstance withKeyStorePassword(String keyStorePassword) {
+        setKeyStorePassword(keyStorePassword);
+        return this;
+    }
+
+    public String getTrustStore() {
+        return trustStore;
+    }
+
+    public void setTrustStore(String trustStore) {
+        this.trustStore = trustStore;
+    }
+    
+    public GraphiteInstance withTrustStore(String trustStore) {
+        setTrustStore(trustStore);
+        return this;
+    }
+
+}

--- a/seyren-core/src/main/java/com/seyren/core/store/GraphiteInstancesStore.java
+++ b/seyren-core/src/main/java/com/seyren/core/store/GraphiteInstancesStore.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.store;
+
+import com.seyren.core.domain.GraphiteInstance;
+import com.seyren.core.domain.SeyrenResponse;
+
+/**
+ * Data access interface for Graphite instances.
+ * 
+ * @author Willie Wheeler (willie.wheeler@gmail.com)
+ */
+public interface GraphiteInstancesStore {
+
+    /**
+     * Creates a new Graphite instance in the persistent store.
+     * 
+     * @param graphiteInstance
+     *            Graphite instance to create
+     * @return newly-created Graphite instance
+     */
+    GraphiteInstance createGraphiteInstance(GraphiteInstance graphiteInstance);
+
+    /**
+     * Returns all Graphite instances from the persistent store.
+     * 
+     * @return all Graphite instances
+     */
+    SeyrenResponse<GraphiteInstance> getGraphiteInstances();
+
+    /**
+     * Returns a specific Graphite instance from the persistent store.
+     * 
+     * @param graphiteInstanceId
+     *            Graphite instance ID
+     * @return the requested Graphite instance
+     */
+    GraphiteInstance getGraphiteInstance(String graphiteInstanceId);
+
+    /**
+     * Updates the given Graphite instance in the persistent store.
+     * 
+     * @param graphiteInstance
+     *            Graphite instance to update
+     * @return the updated Graphite instance
+     */
+    GraphiteInstance updateGraphiteInstance(GraphiteInstance graphiteInstance);
+
+    /**
+     * Deletes the given Graphite instance.
+     * 
+     * @param graphiteInstanceId
+     *            Graphite instance ID
+     */
+    void deleteGraphiteInstance(String graphiteInstanceId);
+}

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -13,7 +13,8 @@
  */
 package com.seyren.core.util.config;
 
-import static org.apache.commons.lang.StringUtils.*;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.stripEnd;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.apache.velocity.app.Velocity;
 import org.apache.velocity.runtime.RuntimeConstants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.seyren.core.domain.GraphiteInstance;
 import com.seyren.core.util.velocity.Slf4jLogChute;
 
 @Named
@@ -32,12 +34,7 @@ public class SeyrenConfig {
     
     private final String baseUrl;
     private final String mongoUrl;
-    private final String graphiteUrl;
-    private final String graphiteUsername;
-    private final String graphitePassword;
-    private final String graphiteKeyStore;
-    private final String graphiteKeyStorePassword;
-    private final String graphiteTrustStore;
+    private final GraphiteInstance graphiteInstance;
     private final String pagerDutyDomain;
     private final String pagerDutyToken;
     private final String pagerDutyUsername;
@@ -64,12 +61,13 @@ public class SeyrenConfig {
         this.mongoUrl = configOrDefault("MONGO_URL", "mongodb://localhost:27017/seyren");
         
         // Graphite
-        this.graphiteUrl = stripEnd(configOrDefault("GRAPHITE_URL", "http://localhost:80"), "/");
-        this.graphiteUsername = configOrDefault("GRAPHITE_USERNAME", "");
-        this.graphitePassword = configOrDefault("GRAPHITE_PASSWORD", "");
-        this.graphiteKeyStore = configOrDefault("GRAPHITE_KEYSTORE", "");
-        this.graphiteKeyStorePassword = configOrDefault("GRAPHITE_KEYSTORE_PASSWORD", "");
-        this.graphiteTrustStore = configOrDefault("GRAPHITE_TRUSTSTORE", "");
+        this.graphiteInstance = new GraphiteInstance()
+                .withBaseUrl(stripEnd(configOrDefault("GRAPHITE_URL", "http://localhost:80"), "/"))
+                .withUsername(configOrDefault("GRAPHITE_USERNAME", ""))
+                .withPassword(configOrDefault("GRAPHITE_PASSWORD", ""))
+                .withKeyStore(configOrDefault("GRAPHITE_KEYSTORE", ""))
+                .withKeyStorePassword(configOrDefault("GRAPHITE_KEYSTORE_PASSWORD", ""))
+                .withTrustStore(configOrDefault("GRAPHITE_TRUSTSTORE", ""));
         
         // SMTP
         this.smtpFrom = configOrDefault(list("SMTP_FROM", "SEYREN_FROM_EMAIL"), "alert@seyren");
@@ -196,52 +194,52 @@ public class SeyrenConfig {
     
     @JsonIgnore
     public String getGraphiteUrl() {
-        return graphiteUrl;
+        return graphiteInstance.getBaseUrl();
     }
     
     @JsonIgnore
     public String getGraphiteUsername() {
-        return graphiteUsername;
+        return graphiteInstance.getUsername();
     }
     
     @JsonIgnore
     public String getGraphitePassword() {
-        return graphitePassword;
+        return graphiteInstance.getPassword();
     }
     
     @JsonIgnore
     public String getGraphiteScheme() {
-        return splitBaseUrl(graphiteUrl)[0];
+        return splitBaseUrl(getGraphiteUrl())[0];
     }
     
     @JsonIgnore
     public int getGraphiteSSLPort() {
-        return Integer.valueOf(splitBaseUrl(graphiteUrl)[1]);
+        return Integer.valueOf(splitBaseUrl(getGraphiteUrl())[1]);
     }
     
     @JsonIgnore
     public String getGraphiteHost() {
-        return splitBaseUrl(graphiteUrl)[2];
+        return splitBaseUrl(getGraphiteUrl())[2];
     }
     
     @JsonIgnore
     public String getGraphitePath() {
-        return splitBaseUrl(graphiteUrl)[3];
+        return splitBaseUrl(getGraphiteUrl())[3];
     }
     
     @JsonIgnore
     public String getGraphiteKeyStore() {
-        return graphiteKeyStore;
+        return graphiteInstance.getKeyStore();
     }
     
     @JsonIgnore
     public String getGraphiteKeyStorePassword() {
-        return graphiteKeyStorePassword;
+        return graphiteInstance.getKeyStorePassword();
     }
     
     @JsonIgnore
     public String getGraphiteTrustStore() {
-        return graphiteTrustStore;
+        return graphiteInstance.getTrustStore();
     }
     
     private static String configOrDefault(String propertyName, String defaultValue) {

--- a/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
@@ -13,8 +13,8 @@
  */
 package com.seyren.core.util.config;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,21 +28,25 @@ public class SeyrenConfigTest {
         config = new SeyrenConfig();
     }
     
+    // FIXME This fails when SEYREN_URL is set to something else. [WLW]
     @Test
     public void defaultBaseUrlIsCorrect() {
         assertThat(config.getBaseUrl(), is("http://localhost:8080/seyren"));
     }
     
+    // FIXME This fails when MONGO_URL is set to something else. [WLW]
     @Test
     public void defaultMongoUrlIsCorrect() {
         assertThat(config.getMongoUrl(), is("mongodb://localhost:27017/seyren"));
     }
     
+    // FIXME This fails when GRAPHITE_URL is set to something else. [WLW]
     @Test
     public void defaultGraphiteUrlIsCorrect() {
         assertThat(config.getGraphiteUrl(), is("http://localhost:80"));
     }
     
+    // FIXME Etc. [WLW]
     @Test
     public void defaultGraphiteUsernameIsCorrect() {
         assertThat(config.getGraphiteUsername(), is(""));

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
@@ -29,6 +29,7 @@ import com.mongodb.DBObject;
 import com.seyren.core.domain.Alert;
 import com.seyren.core.domain.AlertType;
 import com.seyren.core.domain.Check;
+import com.seyren.core.domain.GraphiteInstance;
 import com.seyren.core.domain.Subscription;
 import com.seyren.core.domain.SubscriptionType;
 
@@ -122,6 +123,27 @@ public class MongoMapper {
                 .withTimestamp(timestamp);
     }
     
+    public GraphiteInstance graphiteInstanceFrom(DBObject dbo) {
+        String id = dbo.get("_id").toString();
+        String name = getString(dbo, "name");
+        String baseUrl = getString(dbo, "baseUrl");
+        String username = getString(dbo, "username");
+        String password = getString(dbo, "password");
+        String keyStore = getString(dbo, "keyStore");
+        String keyStorePassword = getString(dbo, "keyStorePassword");
+        String trustStore = getString(dbo, "trustStore");
+        
+        return new GraphiteInstance()
+                .withId(id)
+                .withName(name)
+                .withBaseUrl(baseUrl)
+                .withUsername(username)
+                .withPassword(password)
+                .withKeyStore(keyStore)
+                .withKeyStorePassword(keyStorePassword)
+                .withTrustStore(trustStore);
+    }
+    
     public DBObject checkToDBObject(Check check) {
         return new BasicDBObject(propertiesToMap(check));
     }
@@ -132,6 +154,10 @@ public class MongoMapper {
     
     public DBObject alertToDBObject(Alert alert) {
         return new BasicDBObject(propertiesToMap(alert));
+    }
+    
+    public DBObject graphiteInstanceToDBObject(GraphiteInstance graphiteInstance) {
+        return new BasicDBObject(propertiesToMap(graphiteInstance));
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -203,6 +229,20 @@ public class MongoMapper {
         map.put("fromType", alert.getFromType().toString());
         map.put("toType", alert.getToType().toString());
         map.put("timestamp", new Date(alert.getTimestamp().getMillis()));
+        return map;
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private Map propertiesToMap(GraphiteInstance graphiteInstance) {
+        Map map = new HashMap();
+        map.put("_id", graphiteInstance.getId());
+        map.put("name", graphiteInstance.getName());
+        map.put("baseUrl", graphiteInstance.getBaseUrl());
+        map.put("username", graphiteInstance.getUsername());
+        map.put("password", graphiteInstance.getPassword());
+        map.put("keyStore", graphiteInstance.getKeyStore());
+        map.put("keyStorePassword", graphiteInstance.getKeyStorePassword());
+        map.put("trustStore", graphiteInstance.getTrustStore());
         return map;
     }
     


### PR DESCRIPTION
...sue #134:

Seyren Core:
- Added domain object.
- Added store interface with basic CRUD operations.
- Updated SeyrenConfig to use the GraphiteInstance to encapsulate individual Graphite fields.

Seyren Mongo:
- Updated MongoStore and MongoMapper to support the store interface.

Seyren API:
- Added REST API interface for GraphiteInstance.
- Added bean to implement the interface.

Seyren Acceptance Tests:
- Implemented basic acceptance tests for the GraphiteInstance endpoints.

Haven't implemented anything on the UI yet, as I figure it makes sense to treat all of this as
a "dark launch" until we update the checks to use it.
