### PR TITLE
Add absolute class to fix styling issue

### DIFF
--- a/seyren-web/src/main/webapp/css/override-bootstrap.css
+++ b/seyren-web/src/main/webapp/css/override-bootstrap.css
@@ -31,3 +31,7 @@ body {
 .footer-links li:first-child {
     padding-left: 0;
 }
+
+.absolute {
+    position: absolute;
+}

--- a/seyren-web/src/main/webapp/html/check.html
+++ b/seyren-web/src/main/webapp/html/check.html
@@ -196,12 +196,12 @@
         </div>
     </div>
 
-    <div class="modal hide" tabindex="-1" ng-include="'./html/modal-partial-subscription.html'" id="editSubscriptionModal">
+    <div class="absolute modal hide" tabindex="-1" ng-include="'./html/modal-partial-subscription.html'" id="editSubscriptionModal">
     </div>
 
-    <div class="modal hide" tabindex="-1" ng-include="'./html/modal-partial-check.html'" id="editCheckModal">
+    <div class="absolute modal hide" tabindex="-1" ng-include="'./html/modal-partial-check.html'" id="editCheckModal">
     </div>
-    
+
 </div>
 
 

--- a/seyren-web/src/main/webapp/html/checks.html
+++ b/seyren-web/src/main/webapp/html/checks.html
@@ -43,8 +43,8 @@
             </table>
             <p ng-hide="checks.values.length > 0">We've got no checks. Why not create one?</p>
         </div>
-        
-        <div class="modal hide" tabindex="-1" ng-include="'./html/modal-partial-check.html'" id="editCheckModal">
+
+        <div class="absolute modal hide" tabindex="-1" ng-include="'./html/modal-partial-check.html'" id="editCheckModal">
         </div>
     </div>
 </div>


### PR DESCRIPTION
Problem: No scroll, so button to create checks is inaccessible on certain screen resolutions:

![image](https://f.cloud.github.com/assets/1064715/1271080/18f9ce66-2d15-11e3-8279-57f25cc29d3b.png)

Solution: Change divs to absolute, allows scrolling

See it in action here: http://tranquil-ocean-1950.herokuapp.com/ (Note will die after 48 hours)

Not sure how you feel about styling changes, but this would be really useful :+1: 
