### PR TITLE
Make a one jar file monolithic #149

### DIFF
--- a/seyren-web/pom.xml
+++ b/seyren-web/pom.xml
@@ -113,6 +113,18 @@
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>
                 <version>2.1</version>
+                <executions>
+                    <execution>
+                        <id>tomcat-run</id>
+                        <goals>
+                            <goal>exec-war-only</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                          <path>/</path>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <port>8080</port>
                     <path>/seyren</path>


### PR DESCRIPTION
Use tomcat7-maven-plugin to build an executable jar, see target/seyren-web-1.0.0-SNAPSHOT-war-exec.jar.

% java -jar seyren-web-1.0.0-SNAPSHOT-war-exec.jar
...
INFO: Starting Servlet Engine: Apache Tomcat/7.0.37
...
INFO: Starting ProtocolHandler ["http-bio-8080"]

Implementation notes:
- tomcat7-maven-plugin 2.2 does not work
- You can change http port with: jar target/seyren-web-1.0.0-SNAPSHOT-war-exec.jar -httpPort=9090
- tomcat7-maven-plugin creates seyren-web-1.0.0-SNAPSHOT-war-exec.jar but installs seyren-web-1.0.0-SNAPSHOT-exec-war.jar -> wierd
