### PR TITLE
Issue-93 Add subscription when creating check (partial REST API only)

### DIFF
--- a/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ChecksAT.java
+++ b/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ChecksAT.java
@@ -74,6 +74,16 @@ public class ChecksAT {
         assertThat(get(location).asJson(), hasJsonPath("$.state", is("ERROR")));
         deleteLocation(location);
     }
+
+    @Test
+    public void testCreateCheckWithSubscriptionIncluded() {
+        Response response = createCheck("{ \"name\": \"test\", \"warn\": 1.0, \"error\": 0, " +
+                "\"subscriptions\": [ { \"target\": \"nobody@test.com\", \"type\":\"EMAIL\" } ] }");
+        assertThat(response, hasStatusCode(201));
+        String location = response.getHeader("Location").getValue();
+        assertThat(get(location).asJson(), hasJsonPath("$.subscriptions", hasSize(1)));
+        deleteLocation(location);
+    }
     
     @Test
     public void testUpdateHandlesNullLastCheckDate() {

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bson.types.ObjectId;
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
 
@@ -31,6 +32,7 @@ import com.seyren.core.domain.AlertType;
 import com.seyren.core.domain.Check;
 import com.seyren.core.domain.Subscription;
 import com.seyren.core.domain.SubscriptionType;
+import org.python.antlr.op.Sub;
 
 public class MongoMapper {
     
@@ -154,6 +156,18 @@ public class MongoMapper {
         map.put("state", check.getState().toString());
         if (check.getLastCheck() != null) {
             map.put("lastCheck", new Date(check.getLastCheck().getMillis()));
+        }
+        if (check.getSubscriptions() != null && !check.getSubscriptions().isEmpty()) {
+            final ArrayList<DBObject> dbSubscriptions = new ArrayList<DBObject>();
+            for (Subscription s : check.getSubscriptions()) {
+                final BasicDBObject dbObject = new BasicDBObject(propertiesToMap(s));
+                if (dbObject.get("_id") == null) {
+                    dbObject.put("_id", new ObjectId().toStringMongod());
+                }
+                dbSubscriptions.add(dbObject);
+            }
+
+            map.put("subscriptions", dbSubscriptions);
         }
         return map;
     }


### PR DESCRIPTION
POST to /checks API now supports persisting nested subsciption objects.
New acceptance test.
This patch does NOT address the UX changes necessary to create
subscriptions concurrently with checks, but is more narrowly focused at
supporting scripts.  It will generalize once someone is able to properly
factor the partials out in the angular.
