### PR TITLE
Fix an invalid char in the Docker Seyren Image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following options can be supplied as system properties or environment variab
 You can use [Seyren Cookbook](https://github.com/obazoud/chef-seyren) to deploy Seyren with [Chef](http://www.getchef.com/).
 
 ##Docker
-You can use the [Docker Seyren Image](https://registry.hub.docker.com/u/usman/docker-seyren/[) to deploy a seyren instance in a [docker](https://docker.com/https://docker.com/) container.
+You can use the [Docker Seyren Image](https://registry.hub.docker.com/u/usman/docker-seyren/) to deploy a seyren instance in a [docker](https://docker.com/https://docker.com/) container.
 
 ##Development
 


### PR DESCRIPTION
Removed a `[` from the url that showed you a 404 error.
