### PR TITLE
Fixed Slack notification

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
@@ -34,6 +34,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ import com.seyren.core.util.config.SeyrenConfig;
 @Named
 public class SlackNotificationService implements NotificationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SlackNotificationService.class);
-    
+
     private final SeyrenConfig seyrenConfig;
     private final String baseUrl;
 
@@ -81,8 +82,6 @@ public class SlackNotificationService implements NotificationService {
 
         String url = String.format("%s/api/chat.postMessage", baseUrl);
         HttpClient client = HttpClientBuilder.create().build();
-        HttpPost post = new HttpPost(url);
-        post.addHeader("accept", "application/json");
 
         List<BasicNameValuePair> parameters = new ArrayList<BasicNameValuePair>();
         parameters.add(new BasicNameValuePair("token", token));
@@ -91,8 +90,10 @@ public class SlackNotificationService implements NotificationService {
         parameters.add(new BasicNameValuePair("username", username));
         parameters.add(new BasicNameValuePair("icon_url", iconUrl));
 
+        HttpPost post = new HttpPost(url+"?"+URLEncodedUtils.format(parameters, "UTF-8"));
+        post.addHeader("accept", "application/json");
+
         try {
-            post.setEntity(new UrlEncodedFormEntity(parameters));
             HttpResponse response = client.execute(post);
             if (LOGGER.isDebugEnabled()) {
               LOGGER.debug("Status: {}, Body: {}", response.getStatusLine(), new BasicResponseHandler().handleResponse(response));
@@ -103,14 +104,14 @@ public class SlackNotificationService implements NotificationService {
             post.releaseConnection();
             HttpClientUtils.closeQuietly(client);
         }
-        
+
     }
-    
+
     @Override
     public boolean canHandle(SubscriptionType subscriptionType) {
         return subscriptionType == SubscriptionType.SLACK;
     }
-    
+
     private String formatContent(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) {
         String url = String.format("%s/#/checks/%s", seyrenConfig.getBaseUrl(), check.getId());
         String alertsString = Joiner.on(", ").join(transform(alerts, new Function<Alert, String>() {


### PR DESCRIPTION
Slack notification didn't work on 1.1.0. The problem seems to be that you are trying to send an URL encoded form which get sent in the body of the POST while the API requires the values to be sent as URL encoded parameters (https://api.slack.com/methods/chat.postMessage)

Bruno
