### PR TITLE
Add jetty-jsp to remove like NoClassDefFoundError: org/apache/jasper/run...

### DIFF
--- a/seyren-acceptance-tests/pom.xml
+++ b/seyren-acceptance-tests/pom.xml
@@ -155,6 +155,18 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-nop</artifactId>
+                        <version>${org.slf4j.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-jsp</artifactId>
+                        <version>${org.eclipse.jetty.version}</version>
+                   </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/seyren-integration-tests/pom.xml
+++ b/seyren-integration-tests/pom.xml
@@ -175,6 +175,11 @@
                                 <artifactId>slf4j-nop</artifactId>
                                 <version>${org.slf4j.version}</version>
                             </dependency>
+                            <dependency>
+                                <groupId>org.eclipse.jetty</groupId>
+                                <artifactId>jetty-jsp</artifactId>
+                                <version>${org.eclipse.jetty.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
...time/JspApplicationContextImpl or NoClassDefFoundError: org/eclipse/jetty/servlet/FilterMapping
