### PR TITLE
 fixes state *and* lastCheck

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunner.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunner.java
@@ -120,15 +120,14 @@ public class CheckRunner implements Runnable {
                 interestingAlerts.add(alert);
                 
             }
-            
-            checksStore.updateStateAndLastCheck(check.getId(), worstState, DateTime.now());
-            check.setState(worstState);
-            
+
+            Check updatedCheck = checksStore.updateStateAndLastCheck(check.getId(), worstState, DateTime.now());
+
             if (interestingAlerts.isEmpty()) {
                 return;
             }
             
-            for (Subscription subscription : check.getSubscriptions()) {
+            for (Subscription subscription : updatedCheck.getSubscriptions()) {
                 if (!subscription.shouldNotify(now, worstState)) {
                     continue;
                 }
@@ -136,7 +135,7 @@ public class CheckRunner implements Runnable {
                 for (NotificationService notificationService : notificationServices) {
                     if (notificationService.canHandle(subscription.getType())) {
                         try {
-                            notificationService.sendNotification(check, subscription, interestingAlerts);
+                            notificationService.sendNotification(updatedCheck, subscription, interestingAlerts);
                         } catch (Exception e) {
                             LOGGER.warn("Notifying {} by {} failed.", subscription.getTarget(), subscription.getType(), e);
                         }

--- a/seyren-core/src/main/java/com/seyren/core/store/ChecksStore.java
+++ b/seyren-core/src/main/java/com/seyren/core/store/ChecksStore.java
@@ -48,6 +48,6 @@ public interface ChecksStore {
     
     Check saveCheck(Check check);
 
-    void updateStateAndLastCheck(String checkId, AlertType state, DateTime lastCheck);
+    Check updateStateAndLastCheck(String checkId, AlertType state, DateTime lastCheck);
     
 }

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
@@ -254,7 +254,7 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
     }
     
     @Override
-    public void updateStateAndLastCheck(String checkId, AlertType state, DateTime lastCheck) {
+    public Check updateStateAndLastCheck(String checkId, AlertType state, DateTime lastCheck) {
         DBObject findObject = forId(checkId);
         
         DBObject partialObject = object("lastCheck", new Date(lastCheck.getMillis()))
@@ -263,6 +263,8 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
         DBObject setObject = object("$set", partialObject);
         
         getChecksCollection().update(findObject, setObject);
+
+        return getCheck(checkId);
     }
     
     @Override


### PR DESCRIPTION
regressions introduced by 53f5f9c
- 3c5b61a fix only wrong state

This commit fixes state _and_ lastCheck - updateStateAndLastCheck hits
mongo to read check
