### PR TITLE
Allow checks to specify whether no data should appear as OK

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/domain/Check.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/Check.java
@@ -47,6 +47,7 @@ public class Check {
     private BigDecimal error;
     private boolean enabled;
     private boolean live;
+    private boolean allowNoData;
     private AlertType state;
     private DateTime lastCheck;
     private List<Subscription> subscriptions = new ArrayList<Subscription>();
@@ -184,7 +185,20 @@ public class Check {
         setLive(live);
         return this;
     }
-
+    
+    public boolean isAllowNoData() {
+        return allowNoData;
+    }
+    
+    public void setAllowNoData(boolean allowNoData) {
+        this.allowNoData = allowNoData;
+    }
+    
+    public Check withAllowNoData(boolean allowNoData) {
+        setAllowNoData(allowNoData);
+        return this;
+    }
+    
     public AlertType getState() {
         return state;
     }

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunner.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunner.java
@@ -64,15 +64,17 @@ public class CheckRunner implements Runnable {
         try {
             Map<String, Optional<BigDecimal>> targetValues = targetChecker.check(check);
             
-            if (targetValues.isEmpty()) {
-                return;
-            }
-            
             DateTime now = new DateTime();
             BigDecimal warn = check.getWarn();
             BigDecimal error = check.getError();
             
-            AlertType worstState = AlertType.UNKNOWN;
+            AlertType worstState;
+            
+            if (check.isAllowNoData()) {
+                worstState = AlertType.OK;
+            } else {
+                worstState = AlertType.UNKNOWN;
+            }
             
             List<Alert> interestingAlerts = new ArrayList<Alert>();
             

--- a/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckRunnerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckRunnerTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.core.service.schedule;
 
 import static org.mockito.Matchers.*;
@@ -64,10 +77,25 @@ public class CheckRunnerTest {
     }
     
     @Test
-    public void noTargetValuesDoesNothing() throws Exception {
+    public void noTargetValuesUpdatesLastCheckWithUnknown() throws Exception {
+        when(mockCheck.getId()).thenReturn("id");
         when(mockCheck.isEnabled()).thenReturn(true);
+        when(mockCheck.isAllowNoData()).thenReturn(false);
         when(mockTargetChecker.check(mockCheck)).thenReturn(new HashMap<String, Optional<BigDecimal>>());
+        when(mockChecksStore.updateStateAndLastCheck(eq("id"), eq(AlertType.UNKNOWN), any(DateTime.class))).thenReturn(mockCheck);
         checkRunner.run();
+        verify(mockChecksStore).updateStateAndLastCheck(eq("id"),  eq(AlertType.UNKNOWN), any(DateTime.class));
+    }
+    
+    @Test
+    public void noTargetValuesButAllowNoDataUpdatesLastCheckWithOk() throws Exception {
+        when(mockCheck.getId()).thenReturn("id");
+        when(mockCheck.isEnabled()).thenReturn(true);
+        when(mockCheck.isAllowNoData()).thenReturn(true);
+        when(mockTargetChecker.check(mockCheck)).thenReturn(new HashMap<String, Optional<BigDecimal>>());
+        when(mockChecksStore.updateStateAndLastCheck(eq("id"), eq(AlertType.OK), any(DateTime.class))).thenReturn(mockCheck);
+        checkRunner.run();
+        verify(mockChecksStore).updateStateAndLastCheck(eq("id"),  eq(AlertType.OK), any(DateTime.class));
     }
     
     @Test

--- a/seyren-integration-tests/src/test/e2e/scenarios.js
+++ b/seyren-integration-tests/src/test/e2e/scenarios.js
@@ -129,7 +129,7 @@ describe('check page', function () {
     });
 
     it('should have a \'Details\' informations', function () {
-        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(11);
+        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(12);
 
         expect(element('div.col-lg-6 div.detail-form:eq(0) label').text()).toBe('Name:');
         expect(element('div.col-lg-6 div.detail-form:eq(0) p').text()).toBe('load longterm usage');
@@ -161,8 +161,11 @@ describe('check page', function () {
         expect(element('div.col-lg-6 div.detail-form:eq(9) label').text()).toBe('Live:');
         expect(element('div.col-lg-6 div.detail-form:eq(9) p input:not(:checked)').val()).toBe('on');
 
-        expect(element('div.col-lg-6 div.detail-form:eq(10) label').text()).toBe('Last check:');
-        expect(element('div.col-lg-6 div.detail-form:eq(10) p').text()).toMatch('[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}');
+        expect(element('div.col-lg-6 div.detail-form:eq(10) label').text()).toBe('Allow no data:');
+        expect(element('div.col-lg-6 div.detail-form:eq(10) p input:not(:checked)').val()).toBe('on');
+
+        expect(element('div.col-lg-6 div.detail-form:eq(11) label').text()).toBe('Last check:');
+        expect(element('div.col-lg-6 div.detail-form:eq(11) p').text()).toMatch('[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}');
     });
 
     it('should have \'Graphs\' thumbnail', function () {
@@ -217,7 +220,7 @@ describe('edit check', function () {
     });
 
     it('edit and submit check', function () {
-        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(11);
+        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(12);
 
         expect(element('a:contains("edit")').count()).toBe(1);
         expect(element('div#editCheckModal:visible').count()).toBe(0);

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
@@ -47,6 +47,7 @@ public class MongoMapper {
         BigDecimal error = getBigDecimal(dbo, "error");
         boolean enabled = getBoolean(dbo, "enabled");
         boolean live = getOptionalBoolean(dbo, "live", false);
+        boolean allowNoData = getOptionalBoolean(dbo, "allowNoData", false);
         AlertType state = AlertType.valueOf(getString(dbo, "state"));
         DateTime lastCheck = getDateTime(dbo, "lastCheck");
         List<Subscription> subscriptions = new ArrayList<Subscription>();
@@ -65,6 +66,7 @@ public class MongoMapper {
                 .withError(error)
                 .withEnabled(enabled)
                 .withLive(live)
+                .withAllowNoData(allowNoData)
                 .withState(state)
                 .withLastCheck(lastCheck)
                 .withSubscriptions(subscriptions);
@@ -159,6 +161,7 @@ public class MongoMapper {
         }
         map.put("enabled", check.isEnabled());
         map.put("live", check.isLive());
+        map.put("allowNoData", check.isAllowNoData());
         map.put("state", check.getState().toString());
         if (check.getLastCheck() != null) {
             map.put("lastCheck", new Date(check.getLastCheck().getMillis()));

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
@@ -244,6 +244,7 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
                 .with("error", check.getError().toPlainString())
                 .with("enabled", check.isEnabled())
                 .with("live", check.isLive())
+                .with("allowNoData", check.isAllowNoData())
                 .with("lastCheck", lastCheck == null ? null : new Date(lastCheck.getMillis()))
                 .with("state", check.getState().toString());
         

--- a/seyren-web/src/main/webapp/html/check.html
+++ b/seyren-web/src/main/webapp/html/check.html
@@ -85,6 +85,12 @@
                 </div>
             </div>
             <div class="form-group detail-form">
+                <label class="col-lg-2 control-label">Allow no data:</label>
+                <div class="col-lg-10">
+                    <p class="form-control-static"><input type="checkbox" ng-checked="check.allowNoData" ng-click="swapCheckAllowNoDataEnabled(check)" /> </p>
+                </div>
+            </div>
+            <div class="form-group detail-form">
                 <label class="col-lg-2 control-label">Last check:</label>
                 <div class="col-lg-10">
                     <p class="form-control-static">{{check.lastCheck | date: 'yyyy-MM-dd HH:mm:ss'}}</p>

--- a/seyren-web/src/main/webapp/html/modal-partial-check.html
+++ b/seyren-web/src/main/webapp/html/modal-partial-check.html
@@ -69,6 +69,14 @@
                         </label>
                     </div>
                 </div>
+                <div ng-class="{ 'form-group': true, 'has-error': checkForm['check.allowNoData'].$invalid }">
+                    <label class="col-sm-3 control-label" for="check.allowNoData">Allow no data</label>
+                    <div class="col-sm-1">
+                        <label class="checkbox inline">
+                            <input id="check.allowNoData" name="check.allowNoData" ng-model="check.allowNoData" type="checkbox" ng-checked="check.allowNoData">
+                        </label>
+                    </div>
+                </div>
                 <div class="form-group">
                     <div class="col-sm-7 col-sm-offset-3">
                         <img ng-src="{{ check.previewImage }}" src="./img/preview-nodata.png" width="300" height="70" />

--- a/seyren-web/src/main/webapp/js/check-controller.js
+++ b/seyren-web/src/main/webapp/js/check-controller.js
@@ -132,6 +132,10 @@
             $scope.loadCheck();
         });
 
+        $scope.$on('check:swapCheckAllowNoDataEnabled', function () {
+            $scope.loadCheck();
+        });
+
         $scope.swapCheckEnabled = function (check) {
             Seyren.swapCheckEnabled(check);
         };
@@ -142,6 +146,10 @@
 
         $scope.swapCheckLiveEnabled = function (check) {
             Seyren.swapCheckLiveEnabled(check);
+        };
+
+        $scope.swapCheckAllowNoDataEnabled = function (check) {
+            Seyren.swapCheckAllowNoDataEnabled(check);
         };
 
         $scope.editSubscription = function (check, subscription) {

--- a/seyren-web/src/main/webapp/js/check-edit-controller.js
+++ b/seyren-web/src/main/webapp/js/check-edit-controller.js
@@ -12,6 +12,7 @@
             previewImage: "./img/preview-nodata.png",
             enabled: true,
             live: false,
+            allowNoData: false,
             totalMetric: '-'
         };
 

--- a/seyren-web/src/main/webapp/js/services.js
+++ b/seyren-web/src/main/webapp/js/services.js
@@ -183,6 +183,14 @@
                     }, function (err) {
                         console.log('Saving check failed');
                     });
+                },
+                swapCheckAllowNoDataEnabled: function (check) {
+                    check.allowNoData = !check.allowNoData;
+                    Checks.update({ checkId:  check.id}, check, function (data) {
+                        $rootScope.$broadcast('check:swapCheckAllowNoDataEnabled');
+                    }, function (err) {
+                        console.log('Saving check failed');
+                    });
                 }
             };
         });


### PR DESCRIPTION
We have a situation here where a service redeployment will cause Graphite metrics to disappear until another warning or error is received by the service. In this case the Seyren check will go to `UNKNOWN` and appear in the list of checks in an unhealthy state.

This pull request makes it possible to allow (on a per-check basis) no data (a Graphite response of `[]` is what we get) to appear as `OK`.