### PR TITLE
Alert the whole channel to a slack notification.

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
@@ -85,6 +85,7 @@ public class SlackNotificationService implements NotificationService {
         parameters.add(new BasicNameValuePair("text", formatContent(emojis, check, subscription, alerts)));
         parameters.add(new BasicNameValuePair("username", username));
         parameters.add(new BasicNameValuePair("icon_url", iconUrl));
+        parameters.add(new BasicNameValuePair("link_names", "1"));
 
         try {
             post.setEntity(new UrlEncodedFormEntity(parameters));
@@ -121,7 +122,7 @@ public class SlackNotificationService implements NotificationService {
 
         final String state = check.getState().toString();
 
-        return String.format("%s%s %s [%s]\n```\n%s\n```\n#%s",
+        return String.format("%s%s %s [%s]\n```\n%s\n```\n@channel #%s",
                 Iterables.get(emojis, check.getState().ordinal(), ""),
                 state,
                 check.getName(),


### PR DESCRIPTION
Not 100% sure about this to be honest. It flags all Slack notifications with the `@channel` directive so that anyone in the channel will be nudged about the notification as a desktop notification (assuming that they haven't switched them off of course).

However, do we want to force this on people or just leave them to configure (say) "#error" as a 'highlight word' in the Slack preferences - this would achieve the same thing ultimately.