### PR TITLE
Update SNMP traps

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
@@ -72,17 +72,22 @@ public class SnmpTrapNotificationService implements NotificationService {
             trap.setType(PDU.TRAP);
 
             OID oid = new OID(seyrenConfig.getSnmpOID());
+            OID name = new OID(seyrenConfig.getSnmpOID()+".1");
+            OID metric = new OID(seyrenConfig.getSnmpOID()+".2");
+            OID state = new OID(seyrenConfig.getSnmpOID()+".3");
+            OID value = new OID(seyrenConfig.getSnmpOID()+".4");
+            OID error = new OID(seyrenConfig.getSnmpOID()+".5");
+            OID warn = new OID(seyrenConfig.getSnmpOID()+".6");
             trap.add(new VariableBinding(SnmpConstants.snmpTrapOID, oid));
             trap.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(5000)));
-            trap.add(variableBinding(SnmpConstants.sysDescr, "Seyren Alert"));
 
             //Add Payload
-            trap.add(variableBinding(oid.append(1), check.getName()));
-            trap.add(variableBinding(oid.append(2), alert.getTarget()));
-            trap.add(variableBinding(oid.append(3), check.getState().name()));
-            trap.add(variableBinding(oid.append(4), alert.getValue().toString()));
-            trap.add(variableBinding(oid.append(5), check.getWarn().toString()));
-            trap.add(variableBinding(oid.append(6), check.getError().toString()));
+            trap.add(variableBinding(name, check.getName()));
+            trap.add(variableBinding(metric, alert.getTarget()));
+            trap.add(variableBinding(state, check.getState().name()));
+            trap.add(variableBinding(value, alert.getValue().toString()));
+            trap.add(variableBinding(warn, check.getWarn().toString()));
+            trap.add(variableBinding(error, check.getError().toString()));
 
             // Send
             sendAlert(check, snmp, target, trap);

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
@@ -77,7 +77,9 @@ public class SnmpTrapNotificationService implements NotificationService {
             OID state = new OID(seyrenConfig.getSnmpOID()+".3");
             OID value = new OID(seyrenConfig.getSnmpOID()+".4");
             OID error = new OID(seyrenConfig.getSnmpOID()+".5");
-            OID warn = new OID(seyrenConfig.getSnmpOID()+".6");
+            OID id = new OID(seyrenConfig.getSnmpOID()+".6");
+	    OID checkUrl = new OID(seyrenConfig.getSnmpOID()+".7");
+
             trap.add(new VariableBinding(SnmpConstants.snmpTrapOID, oid));
             trap.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(5000)));
 
@@ -88,6 +90,8 @@ public class SnmpTrapNotificationService implements NotificationService {
             trap.add(variableBinding(value, alert.getValue().toString()));
             trap.add(variableBinding(warn, check.getWarn().toString()));
             trap.add(variableBinding(error, check.getError().toString()));
+            trap.add(variableBinding(id, check.getId()));
+	    trap.add(variableBinding(checkUrl, String.format("%s/#/checks/%s", seyrenConfig.getBaseUrl(), check.getId())));
 
             // Send
             sendAlert(check, snmp, target, trap);

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
@@ -77,12 +77,12 @@ public class SnmpTrapNotificationService implements NotificationService {
             trap.add(variableBinding(SnmpConstants.sysDescr, "Seyren Alert"));
 
             //Add Payload
-            trap.add(variableBinding(oid, check.getName()));
-            trap.add(variableBinding(oid, alert.getTarget()));
-            trap.add(variableBinding(oid, check.getState().name()));
-            trap.add(variableBinding(oid, alert.getValue().toString()));
-            trap.add(variableBinding(oid, check.getWarn().toString()));
-            trap.add(variableBinding(oid, check.getError().toString()));
+            trap.add(variableBinding(oid.append(1), check.getName()));
+            trap.add(variableBinding(oid.append(2), alert.getTarget()));
+            trap.add(variableBinding(oid.append(3), check.getState().name()));
+            trap.add(variableBinding(oid.append(4), alert.getValue().toString()));
+            trap.add(variableBinding(oid.append(5), check.getWarn().toString()));
+            trap.add(variableBinding(oid.append(6), check.getError().toString()));
 
             // Send
             sendAlert(check, snmp, target, trap);

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SnmpTrapNotificationService.java
@@ -77,8 +77,9 @@ public class SnmpTrapNotificationService implements NotificationService {
             OID state = new OID(seyrenConfig.getSnmpOID()+".3");
             OID value = new OID(seyrenConfig.getSnmpOID()+".4");
             OID error = new OID(seyrenConfig.getSnmpOID()+".5");
-            OID id = new OID(seyrenConfig.getSnmpOID()+".6");
-	    OID checkUrl = new OID(seyrenConfig.getSnmpOID()+".7");
+            OID warn = new OID(seyrenConfig.getSnmpOID()+".6");
+            OID id = new OID(seyrenConfig.getSnmpOID()+".7");
+	    OID checkUrl = new OID(seyrenConfig.getSnmpOID()+".8");
 
             trap.add(new VariableBinding(SnmpConstants.snmpTrapOID, oid));
             trap.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(5000)));


### PR DESCRIPTION
Traps overwrote the same OID, leaving an SNMP trap with no useful information.

I've added individual OID values for each aspect of the alert.
Ideally, someone should get a Seyren specific OID to use, rather than expect a custom OID, Seyren should define and use its own.