### PR TITLE
fixed hard coded number of execution threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following options can be supplied as system properties or environment variab
 * `SEYREN_URL` - The location of your Seyren instance. Default: `http://localhost:8080/seyren`
 * `SEYREN_LOG_PATH` - The path of seyren.log. Default: ``. If a value is set, it must end with a '/'.
 * `SEYREN_LOG_FILE_LEVEL` - The level of messages logged to the `file` appender (must correspond to a [Logback](http://logback.qos.ch/) log level. So one of `trace`, `debug`, `info`, `warn` or `error`). Default: `info`.
+* `SEYREN_THREADS` - The number of pooled check threads to start. Default: `8`
 * `GRAPHS_ENABLE` - Show(true) or hide(false) graphs in check page. Default: `true`.
 
 ##### [Graphite](http://graphite.readthedocs.org/en/latest/)

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
@@ -22,6 +22,7 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.seyren.core.util.config.SeyrenConfig;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -31,14 +32,16 @@ import com.seyren.core.store.ChecksStore;
 @Named
 public class CheckScheduler {
     
-    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(8, new ThreadFactoryBuilder().setNameFormat("seyren.check-scheduler-%s").setDaemon(false).build());
+    private final ScheduledExecutorService executor;
     private final ChecksStore checksStore;
     private final CheckRunnerFactory checkRunnerFactory;
     
     @Inject
-    public CheckScheduler(ChecksStore checksStore, CheckRunnerFactory checkRunnerFactory) {
+    public CheckScheduler(ChecksStore checksStore, CheckRunnerFactory checkRunnerFactory, SeyrenConfig seyrenConfig) {
         this.checksStore = checksStore;
         this.checkRunnerFactory = checkRunnerFactory;
+        this.executor = Executors.newScheduledThreadPool(seyrenConfig.getNoOfThreads(), new ThreadFactoryBuilder().setNameFormat("seyren.check-scheduler-%s")
+                        .setDaemon(false).build());
     }
     
     @Scheduled(fixedRateString = "${GRAPHITE_REFRESH:60000}")

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -78,14 +78,14 @@ public class SeyrenConfig {
     private final String snmpCommunity;
     private final String snmpOID;
     private final String emailTemplateFileName;
-
+    private final int noOfThreads;
     public SeyrenConfig() {
         
         // Base
         this.baseUrl = stripEnd(configOrDefault("SEYREN_URL", DEFAULT_BASE_URL), "/");
         this.mongoUrl = configOrDefault("MONGO_URL", "mongodb://localhost:27017/seyren");
         this.graphsEnable = configOrDefault("GRAPHS_ENABLE", "true");
-        
+        this.noOfThreads = Integer.parseInt(configOrDefault("SEYREN_THREADS", "8"));
         // Graphite
         this.graphiteUrl = stripEnd(configOrDefault("GRAPHITE_URL", "http://localhost:80"), "/");
         this.graphiteUsername = configOrDefault("GRAPHITE_USERNAME", "");
@@ -385,6 +385,11 @@ public class SeyrenConfig {
     }
 
     @JsonIgnore
+    public int getNoOfThreads() {
+        return noOfThreads;
+    }
+
+    @JsonIgnore
     public String getEmailTemplateFileName() { return emailTemplateFileName; }
 
   private static String configOrDefault(String propertyName, String defaultValue) {
@@ -439,4 +444,6 @@ public class SeyrenConfig {
         
         return baseParts;
     }
+
+
 }

--- a/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
@@ -157,5 +157,10 @@ public class SeyrenConfigTest {
     public void defaultEmailTemplateFileIsCorrect() {
         assertThat(config.getEmailTemplateFileName(), is("com/seyren/core/service/notification/email-template.vm"));
     }
+
+    @Test
+    public void defaultNumOfThreadsIsCorrect() {
+        assertThat(config.getNoOfThreads(), is(8));
+    }
     
 }


### PR DESCRIPTION
Hello Seyren Team,

One of the problems our team was facing was the hard coded thread count.  I added a configuration property to allow the user to specify how many threads can be run.  I added a unit test as well.