### PR TITLE
I'm kinda missing an option to use right click on the checks list

### DIFF
--- a/seyren-integration-tests/src/test/e2e/scenarios.js
+++ b/seyren-integration-tests/src/test/e2e/scenarios.js
@@ -99,7 +99,7 @@ describe('checks page', function () {
         expect(element('table thead tr th:eq(4)').text()).toBe('Enabled');
 
         expect(element('table tbody tr').count()).toBe(1);
-        expect(element('table tbody tr td:eq(0)').text()).toBe('load longterm usage');
+        expect(element('table tbody tr td:eq(0) a').text()).toBe('load longterm usage');
         expect(element('table tbody tr td:eq(1) span:visible').text()).toBe('WARN');
         expect(element('table tbody tr td:eq(2)').text()).toBe('0.5');
         expect(element('table tbody tr td:eq(3)').text()).toBe('2.0');

--- a/seyren-web/src/main/webapp/html/checks.html
+++ b/seyren-web/src/main/webapp/html/checks.html
@@ -28,7 +28,9 @@
             </thead>
             <tbody>
                 <tr ng-repeat="check in checks.values  | filter:filter | orderBy:predicate:reverse" ng-click="selectCheck(check.id)" style="cursor: pointer;">
-                    <td title="{{ check.target }}">{{ check.name }}</td>
+                    <td title="{{ check.target }}">
+                        <a href='#/checks/{{ check.id }}'>{{ check.name }}</a>
+                    </td>
                     <td>
                         <span ng-show="check.state == 'UNKNOWN'" class="label label-default">{{ check.state }}</span>
                         <span ng-show="check.state == 'OK'" class="label label-success">{{ check.state }}</span>


### PR DESCRIPTION
Sometimes I want to open several related checks in different tabs,
and there was no easy way to do it, before this commit.