### PR TITLE
Add support for two new check types: http & Jenkins

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/domain/Check.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/Check.java
@@ -51,6 +51,7 @@ public class Check {
     private AlertType state;
     private DateTime lastCheck;
     private List<Subscription> subscriptions = new ArrayList<Subscription>();
+    private Integer checkType;
     
     public String getId() {
         return id;
@@ -77,7 +78,20 @@ public class Check {
         setName(name);
         return this;
     }
-    
+
+    public Integer getCheckType() {
+        return checkType;
+    }
+
+    public void setCheckType(Integer checkType) {
+        this.checkType = checkType;
+    }
+
+    public Check withCheckType(Integer checkType){
+        setCheckType(checkType);
+        return this;
+    }
+
     public String getDescription() {
         return description;
     }

--- a/seyren-core/src/main/java/com/seyren/core/domain/CheckType.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/CheckType.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+public enum CheckType {
+
+    GRAPHITE(1), HTTP(2), JENKINS(3);
+
+    private final int typeId;
+    private static Map<Integer,CheckType> mapCheckTypeIdToType;
+
+    static{
+        mapCheckTypeIdToType = new HashMap<Integer, CheckType>();
+        for (CheckType ct : CheckType.values()){
+            mapCheckTypeIdToType.put(ct.typeId,ct);
+        }
+    }
+    CheckType(int typeId) {
+        this.typeId = typeId;
+    }
+
+    public static CheckType getCheckTypeById(Integer id){
+        CheckType checkType = mapCheckTypeIdToType.get(id);
+        if (checkType==null){
+            return GRAPHITE;
+        }
+        return checkType;
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/HttpResponseValueChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/HttpResponseValueChecker.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.seyren.core.domain.AlertType;
+
+import java.math.BigDecimal;
+
+/**
+ * Created by ohad on 7/17/15.
+ */
+public class HttpResponseValueChecker implements ValueChecker {
+
+    private static final BigDecimal RESPONSE_OK = new BigDecimal(200);
+
+    @Override
+    public AlertType checkValue(BigDecimal value, BigDecimal warn, BigDecimal error) {
+        if (value.equals(RESPONSE_OK)){
+            return AlertType.OK;
+        }
+
+        return AlertType.ERROR;
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/HttpTargetChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/HttpTargetChecker.java
@@ -37,8 +37,14 @@ public class HttpTargetChecker implements TargetChecker{
 
         Map<String, Optional<BigDecimal>> targetValues = new HashMap<String, Optional<BigDecimal>>();
         String url = check.getTarget();
-        HttpResponse response = urlFetcher.sendUrl(url);
-        BigDecimal statusCode = new BigDecimal(response.getStatusLine().getStatusCode());
+        BigDecimal statusCode = null;
+        try{
+            HttpResponse response = urlFetcher.sendUrl(url);
+            statusCode = new BigDecimal(response.getStatusLine().getStatusCode());
+        }catch (Exception e){
+            statusCode = new BigDecimal(404);
+        }
+
         targetValues.put(url,Optional.of(statusCode));
         return targetValues;
     }

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/HttpTargetChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/HttpTargetChecker.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.google.common.base.Optional;
+import com.seyren.core.domain.Check;
+import com.seyren.core.util.http.HttpUrlFetcher;
+import org.apache.http.HttpResponse;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by ohad on 7/17/15.
+ */
+public class HttpTargetChecker implements TargetChecker{
+
+    private HttpUrlFetcher urlFetcher;
+
+    public HttpTargetChecker(HttpUrlFetcher urlFetcher) {
+        this.urlFetcher = urlFetcher;
+    }
+
+    @Override
+    public Map<String, Optional<BigDecimal>> check(Check check) throws Exception {
+
+        Map<String, Optional<BigDecimal>> targetValues = new HashMap<String, Optional<BigDecimal>>();
+        String url = check.getTarget();
+        HttpResponse response = urlFetcher.sendUrl(url);
+        BigDecimal statusCode = new BigDecimal(response.getStatusLine().getStatusCode());
+        targetValues.put(url,Optional.of(statusCode));
+        return targetValues;
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsJobStatus.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsJobStatus.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Created by ohad on 7/19/15.
+ */
+@JsonIgnoreProperties (ignoreUnknown = true)
+public class JenkinsJobStatus {
+
+    private String result;
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public int getJobStatus(){
+        if (result.equalsIgnoreCase("ERROR")){
+            return -1;
+        }else if (result.equalsIgnoreCase("UNSTABLE")){
+            return 0;
+        }else{
+            return 1;
+        }
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsResponseValueChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsResponseValueChecker.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.seyren.core.domain.AlertType;
+
+import java.math.BigDecimal;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+public class JenkinsResponseValueChecker implements ValueChecker {
+
+    private static final BigDecimal JOB_FINISHED_ERROR = new BigDecimal(-1);
+    private static final BigDecimal JOB_FINISHED_UNSTABLE = new BigDecimal(0);
+
+    @Override
+    public AlertType checkValue(BigDecimal value, BigDecimal warn, BigDecimal error) {
+        if (value.equals(JOB_FINISHED_ERROR)){
+            return AlertType.ERROR;
+        }else if (value.equals(JOB_FINISHED_UNSTABLE)){
+            return AlertType.WARN;
+        }
+
+        return AlertType.OK;
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsTargetChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/JenkinsTargetChecker.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.seyren.core.domain.Check;
+import com.seyren.core.util.http.HttpUrlFetcher;
+import org.apache.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+public class JenkinsTargetChecker implements TargetChecker{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JenkinsTargetChecker.class);
+    private static final String JENKINS_JOB_DETAILS_URL = "http://%s/job/%s/lastCompletedBuild/api/json";
+    private final HttpUrlFetcher httpUrlFetcher;
+    private final String username;
+    private final String password;
+    private final ObjectMapper objectMapper;
+    private final String jenkinsServer;
+
+    public JenkinsTargetChecker(HttpUrlFetcher httpUrlFetcher,String jenkinsServer,String username,String password) {
+        this.httpUrlFetcher = httpUrlFetcher;
+        this.jenkinsServer = jenkinsServer;
+        this.username = username;
+        this.password = password;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public Map<String, Optional<BigDecimal>> check(Check check) throws Exception {
+
+        Map<String, Optional<BigDecimal>> targetValues = new HashMap<String, Optional<BigDecimal>>();
+        String url = String.format(JENKINS_JOB_DETAILS_URL,jenkinsServer,check.getTarget());
+        LOGGER.debug("Check jenkins job: {}",url);
+        HttpResponse response = httpUrlFetcher.sendUrl(url,username,password);
+        JenkinsJobStatus jobStatus = objectMapper.readValue(response.getEntity().getContent(),JenkinsJobStatus.class);
+        BigDecimal jobResult = new BigDecimal(jobStatus.getJobStatus());
+        targetValues.put(check.getTarget(),Optional.of(jobResult));
+        return targetValues;
+    }
+}

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunnerFactory.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunnerFactory.java
@@ -14,36 +14,45 @@
 package com.seyren.core.service.schedule;
 
 import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import com.seyren.core.domain.Check;
-import com.seyren.core.service.checker.NoopTargetCheck;
-import com.seyren.core.service.checker.TargetChecker;
-import com.seyren.core.service.checker.ValueChecker;
+import com.seyren.core.service.checker.*;
 import com.seyren.core.service.notification.NotificationService;
 import com.seyren.core.store.AlertsStore;
 import com.seyren.core.store.ChecksStore;
+import com.seyren.core.util.config.SeyrenConfig;
+import com.seyren.core.util.http.HttpUrlFetcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named
 public class CheckRunnerFactory {
-    
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckRunnerFactory.class);
     private final AlertsStore alertsStore;
     private final ChecksStore checksStore;
     private final TargetChecker targetChecker;
     private final ValueChecker valueChecker;
     private final Iterable<NotificationService> notificationServices;
-    
+    private final HttpTargetChecker httpTargetChecker;
+    private final JenkinsTargetChecker jenkinsTargetChecker;
+
     @Inject
     public CheckRunnerFactory(AlertsStore alertsStore, ChecksStore checksStore, TargetChecker targetChecker, ValueChecker valueChecker,
-            List<NotificationService> notificationServices) {
+                              List<NotificationService> notificationServices,HttpUrlFetcher httpUrlFetcher,SeyrenConfig seyrenConfig) {
         this.alertsStore = alertsStore;
         this.checksStore = checksStore;
         this.targetChecker = targetChecker;
         this.valueChecker = valueChecker;
         this.notificationServices = notificationServices;
+        this.httpTargetChecker = new HttpTargetChecker(httpUrlFetcher);
+        this.jenkinsTargetChecker = new JenkinsTargetChecker(httpUrlFetcher,seyrenConfig.getJenkinsServerUrl(),seyrenConfig.getJenkinsUser(),seyrenConfig.getJenkinsPassword());
     }
 
     public CheckRunner create(Check check) {
@@ -54,4 +63,11 @@ public class CheckRunnerFactory {
         return new CheckRunner(check, alertsStore, checksStore, new NoopTargetCheck(value), valueChecker, notificationServices);
     }
 
+    public Runnable createHttpChecker(Check check) {
+        return new CheckRunner(check,alertsStore,checksStore,httpTargetChecker,new HttpResponseValueChecker(),notificationServices);
+    }
+
+    public Runnable createJenkinsChecker(Check check) {
+        return new CheckRunner(check,alertsStore,checksStore,jenkinsTargetChecker,new JenkinsResponseValueChecker(),notificationServices);
+    }
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -84,6 +84,11 @@ public class SeyrenConfig {
     private final String emailSubjectTemplateFileName;
     private final int noOfThreads;
     private final String httpNotificationUrl;
+
+    private final String jenkinsServerUrl;
+    private final String jenkinsUser;
+    private final String jenkinsPassword;
+
     public SeyrenConfig() {
         
         // Base
@@ -165,6 +170,11 @@ public class SeyrenConfig {
         // Template
         this.emailTemplateFileName = configOrDefault("TEMPLATE_EMAIL_FILE_PATH","com/seyren/core/service/notification/email-template.vm");
         this.emailSubjectTemplateFileName = configOrDefault("TEMPLATE_EMAIL_SUBJECT_FILE_PATH","com/seyren/core/service/notification/email-subject-template.vm");
+
+        // Jenkins
+        this.jenkinsServerUrl = configOrDefault("JENKINS_SERVER_URL","");
+        this.jenkinsPassword = configOrDefault("JENKINS_PASSWORD","");
+        this.jenkinsUser = configOrDefault("JENKINS_USER","");
     }
     
     @PostConstruct
@@ -432,11 +442,27 @@ public class SeyrenConfig {
         return victorOpsRestAPIEndpoint;
     }
 
+    @JsonIgnore
+    public String getJenkinsServerUrl() {
+        return jenkinsServerUrl;
+    }
+
+    @JsonIgnore
+    public String getJenkinsUser() {
+        return jenkinsUser;
+    }
+
+    @JsonIgnore
+    public String getJenkinsPassword() {
+        return jenkinsPassword;
+    }
 
   private static String configOrDefault(String propertyName, String defaultValue) {
         return configOrDefault(list(propertyName), defaultValue);
     }
-    
+
+
+
     private static String configOrDefault(List<String> propertyNames, String defaultValue) {
         
         for (String propertyName : propertyNames) {

--- a/seyren-core/src/main/java/com/seyren/core/util/http/HttpUrlFetcher.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/http/HttpUrlFetcher.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import javax.inject.Named;
@@ -34,7 +35,7 @@ public class HttpUrlFetcher {
     }
 
     public HttpResponse sendUrl(String url,String username,String password) throws IOException {
-        HttpClient client = HttpClientBuilder.create().build();
+        HttpClient client = HttpClientBuilder.create().setRetryHandler(new DefaultHttpRequestRetryHandler(3,true)).build();
 
         HttpGet getMethod = new HttpGet(url);
         if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)){

--- a/seyren-core/src/main/java/com/seyren/core/util/http/HttpUrlFetcher.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/http/HttpUrlFetcher.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.util.http;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import javax.inject.Named;
+import java.io.IOException;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+@Named
+public class HttpUrlFetcher {
+
+    public HttpResponse sendUrl(String url) throws IOException {
+        return sendUrl(url,null,null);
+    }
+
+    public HttpResponse sendUrl(String url,String username,String password) throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+
+        HttpGet getMethod = new HttpGet(url);
+        if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)){
+            getMethod = addAuthenticationHeader(getMethod,username,password);
+        }
+
+        return client.execute(getMethod);
+    }
+
+    private HttpGet addAuthenticationHeader(HttpGet getMethod, String username, String password) {
+        String authString = username + ":" + password;
+        byte[] authEncBytes = Base64.encodeBase64(authString.getBytes());
+        String authStringEnc = new String(authEncBytes);
+        getMethod.addHeader("Authorization","Basic " + authStringEnc);
+        return getMethod;
+    }
+}

--- a/seyren-core/src/test/java/com/seyren/core/service/checker/HttpTargetCheckerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/checker/HttpTargetCheckerTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.google.common.base.Optional;
+import com.seyren.core.domain.Check;
+import com.seyren.core.util.http.HttpUrlFetcher;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+public class HttpTargetCheckerTest {
+
+    private static final String URL = "testUrl";
+    private Check check;
+
+    @Before
+    public void setUp() throws Exception {
+        check = mock(Check.class);
+        when(check.getTarget()).thenReturn(URL);
+    }
+
+    @Test
+    public void testSuccessfulRequest() throws Exception {
+        HttpTargetChecker taskChecker = init(200);
+        Map<String, Optional<BigDecimal>> result = taskChecker.check(check);
+        assertEquals("Wrong result",Optional.of(new BigDecimal(200)),result.get(URL));
+    }
+
+    @Test
+    public void testErrorJob() throws Exception {
+        HttpTargetChecker taskChecker = init(501);
+        Map<String, Optional<BigDecimal>> result = taskChecker.check(check);
+        assertEquals("Wrong result",Optional.of(new BigDecimal(501)),result.get(URL));
+    }
+
+    private HttpTargetChecker init(int responseCode) throws IOException {
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(responseCode);
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        HttpUrlFetcher urlFetcher = mock(HttpUrlFetcher.class);
+        when(urlFetcher.sendUrl(URL)).thenReturn(httpResponse);
+        return new HttpTargetChecker(urlFetcher);
+    }
+}

--- a/seyren-core/src/test/java/com/seyren/core/service/checker/JenkinsTargetCheckerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/checker/JenkinsTargetCheckerTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.seyren.core.service.checker;
+
+import com.google.common.base.Optional;
+import com.seyren.core.domain.Check;
+import com.seyren.core.util.http.HttpUrlFetcher;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ohad on 7/18/15.
+ */
+public class JenkinsTargetCheckerTest {
+
+    private static final String JOB_NAME = "JobName";
+    private static final String JENKINS_SERVER = "server:8080";
+    private static final String SUCCESS_RESPONSE = "{\"actions\":[{\"causes\":[{\"shortDescription\":\"Started by timer\"}]},{\"parameters\":[{\"name\":\"EMAIL_FAILURES\",\"value\":true}]},{},{\"buildsByBranchName\":{\"refs/remotes/origin/master\":{\"buildNumber\":20576,\"buildResult\":null,\"marked\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"revision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]}}},\"lastBuiltRevision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"remoteUrls\":[\"git@github.com:windward-ltd/monitoring.git\"],\"scmName\":\"\"},{},{},{\"failCount\":0,\"skipCount\":1,\"totalCount\":59,\"urlName\":\"testReport\"},{},{}],\"artifacts\":[],\"building\":false,\"description\":null,\"duration\":131345,\"estimatedDuration\":149638,\"executor\":null,\"fullDisplayName\":\"monitoring_prod #20576\",\"id\":\"2015-07-19_08-12-00\",\"keepLog\":false,\"number\":20576,\"result\":\"SUCCESS\",\"timestamp\":1437293520404,\"url\":\"http://jenkins.windward.eu:8080/job/monitoring_prod/20576/\",\"builtOn\":\"slave-3\",\"changeSet\":{\"items\":[],\"kind\":\"git\"},\"culprits\":[],\"mavenArtifacts\":{},\"mavenVersionUsed\":\"3.2.1\"}";
+    private static final String ERROR_RESPONSE = "{\"actions\":[{\"causes\":[{\"shortDescription\":\"Started by timer\"}]},{\"parameters\":[{\"name\":\"EMAIL_FAILURES\",\"value\":true}]},{},{\"buildsByBranchName\":{\"refs/remotes/origin/master\":{\"buildNumber\":20576,\"buildResult\":null,\"marked\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"revision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]}}},\"lastBuiltRevision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"remoteUrls\":[\"git@github.com:windward-ltd/monitoring.git\"],\"scmName\":\"\"},{},{},{\"failCount\":0,\"skipCount\":1,\"totalCount\":59,\"urlName\":\"testReport\"},{},{}],\"artifacts\":[],\"building\":false,\"description\":null,\"duration\":131345,\"estimatedDuration\":149638,\"executor\":null,\"fullDisplayName\":\"monitoring_prod #20576\",\"id\":\"2015-07-19_08-12-00\",\"keepLog\":false,\"number\":20576,\"result\":\"ERROR\",\"timestamp\":1437293520404,\"url\":\"http://jenkins.windward.eu:8080/job/monitoring_prod/20576/\",\"builtOn\":\"slave-3\",\"changeSet\":{\"items\":[],\"kind\":\"git\"},\"culprits\":[],\"mavenArtifacts\":{},\"mavenVersionUsed\":\"3.2.1\"}";
+    private static final String UNSTABLE_RESPONSE = "{\"actions\":[{\"causes\":[{\"shortDescription\":\"Started by timer\"}]},{\"parameters\":[{\"name\":\"EMAIL_FAILURES\",\"value\":true}]},{},{\"buildsByBranchName\":{\"refs/remotes/origin/master\":{\"buildNumber\":20576,\"buildResult\":null,\"marked\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"revision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]}}},\"lastBuiltRevision\":{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"branch\":[{\"SHA1\":\"7b393d9640d9affd00e85099bffc723f4d46f262\",\"name\":\"refs/remotes/origin/master\"}]},\"remoteUrls\":[\"git@github.com:windward-ltd/monitoring.git\"],\"scmName\":\"\"},{},{},{\"failCount\":0,\"skipCount\":1,\"totalCount\":59,\"urlName\":\"testReport\"},{},{}],\"artifacts\":[],\"building\":false,\"description\":null,\"duration\":131345,\"estimatedDuration\":149638,\"executor\":null,\"fullDisplayName\":\"monitoring_prod #20576\",\"id\":\"2015-07-19_08-12-00\",\"keepLog\":false,\"number\":20576,\"result\":\"UNSTABLE\",\"timestamp\":1437293520404,\"url\":\"http://jenkins.windward.eu:8080/job/monitoring_prod/20576/\",\"builtOn\":\"slave-3\",\"changeSet\":{\"items\":[],\"kind\":\"git\"},\"culprits\":[],\"mavenArtifacts\":{},\"mavenVersionUsed\":\"3.2.1\"}";
+
+    private Check check;
+    private String jobCheckUrl;
+
+    @Before
+    public void setUp() throws Exception {
+        check = mock(Check.class);
+        when(check.getTarget()).thenReturn(JOB_NAME);
+        this.jobCheckUrl = "http://server:8080/job/JobName/lastCompletedBuild/api/json";
+    }
+
+    @Test
+    public void testSuccessfulJob() throws Exception {
+        JenkinsTargetChecker jenkinsTaskChecker = init(SUCCESS_RESPONSE);
+        Map<String, Optional<BigDecimal>> result = jenkinsTaskChecker.check(check);
+        assertEquals("Wrong result",Optional.of(new BigDecimal(1)),result.get(JOB_NAME));
+    }
+
+    @Test
+    public void testErrorJob() throws Exception {
+        JenkinsTargetChecker jenkinsTaskChecker = init(ERROR_RESPONSE);
+        Map<String, Optional<BigDecimal>> result = jenkinsTaskChecker.check(check);
+        assertEquals("Wrong result",Optional.of(new BigDecimal(-1)),result.get(JOB_NAME));
+    }
+
+    @Test
+    public void testUnstableJob() throws Exception {
+        JenkinsTargetChecker jenkinsTaskChecker = init(UNSTABLE_RESPONSE);
+        Map<String, Optional<BigDecimal>> result = jenkinsTaskChecker.check(check);
+        assertEquals("Wrong result",Optional.of(new BigDecimal(0)),result.get(JOB_NAME));
+    }
+
+    private JenkinsTargetChecker init(String responseMsg) throws IOException {
+        InputStream responseContent = new ByteArrayInputStream(responseMsg.getBytes());
+        HttpEntity httpEntity = mock(HttpEntity.class);
+        when(httpEntity.getContent()).thenReturn(responseContent);
+        HttpResponse response = mock(HttpResponse.class);
+        when(response.getEntity()).thenReturn(httpEntity);
+        HttpUrlFetcher httpUrlFetcher = mock(HttpUrlFetcher.class);
+        when(httpUrlFetcher.sendUrl(eq(jobCheckUrl),anyString(),anyString())).thenReturn(response);
+        return new JenkinsTargetChecker(httpUrlFetcher,JENKINS_SERVER,null,null);
+    }
+
+
+}

--- a/seyren-core/src/test/java/com/seyren/core/service/notification/VictorOpsNotificationServiceTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/notification/VictorOpsNotificationServiceTest.java
@@ -2,6 +2,19 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p/>

--- a/seyren-integration-tests/src/test/resources/com/seyren/integrationtests/mongo/checks/checks_1.json
+++ b/seyren-integration-tests/src/test/resources/com/seyren/integrationtests/mongo/checks/checks_1.json
@@ -8,5 +8,6 @@
     enabled: true,
     state: "WARN",
     "lastCheck": { "$date": "2013-07-12T10:10:00.000Z"},
-    subscriptions: [ ]
+    subscriptions: [ ],
+    checkType: 2
 }

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
@@ -45,6 +45,7 @@ public class MongoMapper {
         String until = Strings.emptyToNull(getString(dbo, "until"));
         BigDecimal warn = getBigDecimal(dbo, "warn");
         BigDecimal error = getBigDecimal(dbo, "error");
+        Integer checkType = getInteger(dbo,"checkType");
         boolean enabled = getBoolean(dbo, "enabled");
         boolean live = getOptionalBoolean(dbo, "live", false);
         boolean allowNoData = getOptionalBoolean(dbo, "allowNoData", false);
@@ -69,7 +70,8 @@ public class MongoMapper {
                 .withAllowNoData(allowNoData)
                 .withState(state)
                 .withLastCheck(lastCheck)
-                .withSubscriptions(subscriptions);
+                .withSubscriptions(subscriptions)
+                .withCheckType(checkType);
     }
     
     public Subscription subscriptionFrom(DBObject dbo) {


### PR DESCRIPTION
First, great project - Very helpful!
Second, i wanted the dashboard to also display our broken jenkins build as well as perform isAlive http check and report when status isn't 200... So i added two new check types.
UI isn't supporting this feature, for now i am manually adding checkType field in mongo when needed but it's a start.