### PR TITLE
Update modal-partial-check.html to use a textarea

### DIFF
--- a/seyren-web/src/main/webapp/html/modal-partial-check.html
+++ b/seyren-web/src/main/webapp/html/modal-partial-check.html
@@ -23,7 +23,7 @@
                 <div ng-class="{ 'form-group': true, 'has-error': checkForm['check.target'].$invalid }">
                     <label class="col-sm-3 control-label" for="check.target">Target</label>
                     <div class="col-sm-7">
-                        <input id="check.target" class="form-control"  name="check.target" ng-model="check.target" type="text" required />
+                        <textarea id="check.target" class="form-control" name="check.target" ng-model="check.target" required />
                     </div>
                 </div>
                 <div ng-class="{ 'form-group': true, 'has-error': checkForm['check.from'].$invalid }">


### PR DESCRIPTION
Use a textarea instead of an input box for the 'target' because input boxes are almost always too small for the stat.

Problem:
![image](https://cloud.githubusercontent.com/assets/4146/9073006/96fd55fa-3acc-11e5-912b-391650962cdc.png)

Solution:
![image](https://cloud.githubusercontent.com/assets/4146/9073053/d7247654-3acc-11e5-9838-172ce024de6b.png)