### PR TITLE
Code quality fixes

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/IrcCatNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/IrcCatNotificationService.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.Socket;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -82,7 +83,7 @@ public class IrcCatNotificationService implements NotificationService {
         Socket socket = new Socket(ircCatHost, ircCatPort);
         Closer closer = Closer.create();
         try {
-            Writer out = closer.register(new OutputStreamWriter(socket.getOutputStream()));
+            Writer out = closer.register(new OutputStreamWriter(socket.getOutputStream(), Charset.forName("UTF-8")));
             out.write(format("%s %s\n", channel, message));
             out.flush();
         } catch (IOException e) {

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/VictorOpsNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/VictorOpsNotificationService.java
@@ -141,8 +141,9 @@ public class VictorOpsNotificationService implements NotificationService {
                 case ERROR:
                 case EXCEPTION:
                     return CRITICAL;
+                default:
+                    return INFO;
             }
-            return INFO;
         }
     }
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/hashing/TargetHash.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/hashing/TargetHash.java
@@ -15,6 +15,8 @@ package com.seyren.core.util.hashing;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
+import java.nio.charset.Charset;
+
 public final class TargetHash {
     
     private TargetHash() {
@@ -24,7 +26,7 @@ public final class TargetHash {
         if (target == null) {
             return null;
         }
-        return new String(DigestUtils.md5(target));
+        return new String(DigestUtils.md5(target), Charset.forName("UTF-8"));
     }
     
 }

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
@@ -67,9 +67,9 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
             String uri = seyrenConfig.getMongoUrl();
             MongoClientURI mongoClientUri = new MongoClientURI(uri);
             MongoClient mongoClient = new MongoClient(mongoClientUri);
-            DB mongo = mongoClient.getDB(mongoClientUri.getDatabase());
-            mongo.setWriteConcern(WriteConcern.ACKNOWLEDGED);
-            this.mongo = mongo;
+            DB mongoDB = mongoClient.getDB(mongoClientUri.getDatabase());
+            mongoDB.setWriteConcern(WriteConcern.ACKNOWLEDGED);
+            this.mongo = mongoDB;
             bootstrapMongo();
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S1943 -  Classes and methods that rely on the default system encoding should not be used
squid:SwitchLastCaseIsDefaultCheck -  "switch" statements should end with a "default" clause
squid:HiddenFieldCheck -  Local variables should not shadow class fields

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.
Kirill Vlasov