### PR TITLE
Fixing squid:S1858 - "toString()" should never be called on a String object

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/notification/HttpNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/HttpNotificationService.java
@@ -122,7 +122,7 @@ public class HttpNotificationService implements NotificationService {
         cal.add(Calendar.HOUR, 1);
         String until = format.format(cal.getTime());
 
-        return "&from=" + until.toString() + "&until=" + from.toString();   
+        return "&from=" + until + "&until=" + from;
     }
     
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -462,9 +462,9 @@ public class SeyrenConfig {
     private static String[] splitBaseUrl(String baseUrl) {
         String[] baseParts = new String[4];
         
-        if (baseUrl.toString().contains("://")) {
-            baseParts[0] = baseUrl.toString().split("://")[0];
-            baseUrl = baseUrl.toString().split("://")[1];
+        if (baseUrl.contains("://")) {
+            baseParts[0] = baseUrl.split("://")[0];
+            baseUrl = baseUrl.split("://")[1];
         } else {
             baseParts[0] = "http";
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1858 - ""toString()"" should never be called on a String object
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1858
Please let me know if you have any questions.
Kirill Vlasov