### PR TITLE
Proposed: Upgrade mongodb-java-driver to 3.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <org.hamcrest.version>1.3</org.hamcrest.version>
         <org.jboss.resteasy.version>3.0.10.Final</org.jboss.resteasy.version>
         <org.mockito.version>1.9.5</org.mockito.version>
-        <org.mongodb.version>2.12.4</org.mongodb.version>
+        <org.mongodb.version>3.2.1</org.mongodb.version>
         <org.python.version>2.5.3</org.python.version>
         <org.slf4j.version>1.7.9</org.slf4j.version>
         <org.snmp4j.version>2.3.3</org.snmp4j.version>

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.Bytes;
-import com.mongodb.CommandFailureException;
+import com.mongodb.MongoCommandException;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
@@ -103,9 +103,9 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
         LOGGER.info("Dropping old indices");
         try {
             getAlertsCollection().dropIndex(new BasicDBObject("checkId", 1).append("target", 1));
-        } catch (CommandFailureException e) {
-            if (e.getCode() != -5) {
-                // -5 is the code which appears when the index doesn't exist (which we're happy with, anything else is bad news) 
+        } catch (MongoCommandException e) {
+            if (e.getCode() != 27) {
+                // 27 is the code which appears when the index doesn't exist (which we're happy with, anything else is bad news)
                 throw e;
             }
         }


### PR DESCRIPTION
This change allowed me to run seyren against Mongodb 3.2.1 without a problem.
There was one class deprecated in the new driver (`CommandFailureException`) and the missing index error code seemed to be changed to 27. I do not know if this is the proper way of implementing support for new driver, but the old driver won't authenticate with new mongodb servers.

Also people seem to have hit already this problem in these issues:
 - https://github.com/scobal/seyren/issues/356
 - https://github.com/scobal/seyren/issues/354