### PR TITLE
Ability to click through check name

### DIFF
--- a/seyren-integration-tests/src/test/e2e/scenarios.js
+++ b/seyren-integration-tests/src/test/e2e/scenarios.js
@@ -23,7 +23,7 @@ describe('home page', function () {
         expect(element('table:eq(0) thead tr th:eq(4)').text()).toBe('Enabled');
 
         expect(element('table:eq(0) tbody tr').count()).toBe(1);
-        expect(element('table:eq(0) tbody tr td:eq(0)').text()).toBe('load longterm usage');
+        expect(element('table:eq(0) tbody tr td:eq(0) a').text()).toBe('load longterm usage');
         expect(element('table:eq(0) tbody tr td:eq(1) span:visible').text()).toBe('WARN');
         expect(element('table:eq(0) tbody tr td:eq(2)').text()).toBe('0.5');
         expect(element('table:eq(0) tbody tr td:eq(3)').text()).toBe('2.0');
@@ -48,7 +48,7 @@ describe('home page', function () {
         expect(element('table:eq(1) tbody tr').count()).toBe(1);
         expect(element('table:eq(1) tbody tr td:eq(0)').text()).toMatch('[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}');
         expect(element('table:eq(1) tbody tr td:eq(1)').text()).toMatch('^.*ago$');
-        expect(element('table:eq(1) tbody tr td:eq(2)').text()).toBe('load longterm usage');
+        expect(element('table:eq(1) tbody tr td:eq(2) a').text()).toBe('load longterm usage');
         expect(element('table:eq(1) tbody tr td:eq(3)').text()).toBe('0.8');
         expect(element('table:eq(1) tbody tr td:eq(4)').text()).toBe('0.5');
         expect(element('table:eq(1) tbody tr td:eq(5)').text()).toBe('2');

--- a/seyren-web/src/main/webapp/html/home.html
+++ b/seyren-web/src/main/webapp/html/home.html
@@ -13,7 +13,9 @@
         </thead>
         <tbody>
             <tr ng-repeat="check in unhealthyChecks.values" ng-click="selectCheck(check.id)" style="cursor: pointer;">
-                <td title="{{ check.target }}">{{ check.name }}</td>
+                <td title="{{ check.target }}">
+                    <a href='#/checks/{{ check.id }}'>{{ check.name }}</a>
+                </td>
                 <td>
                     <span ng-show="check.state == 'UNKNOWN'" class="label label-default">{{ check.state }}</span>
                     <span ng-show="check.state == 'OK'" class="label label-success">{{ check.state }}</span>
@@ -49,7 +51,9 @@
             <tr ng-repeat="alert in alertStream.values" ng-click="selectCheck(alert.checkId)" style="cursor: pointer;">
                 <td>{{ alert.timestamp | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
                 <td><span am-time-ago="alert.timestamp"></span></td>
-                <td title="{{ alert.target }}">{{ checkNames[alert.checkId] }}</span></td>
+                <td title="{{ alert.target }}">
+                    <a href='#/checks/{{ alert.checkId }}'>{{ checkNames[alert.checkId] }}</a>
+                </td>
                 <td>{{ alert.value }}</td>
                 <td>{{ alert.warn }}</td>
                 <td>{{ alert.error }}</td>


### PR DESCRIPTION
This is already implemented for "Checks" page. This adds the possibility
to click through for the main Seyren page

This fixes #369