### PR TITLE
Use Slack webhook instead of API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ To generate a "Service API Key", see [PagerDuty Support: Adding Services](https:
 
 ##### [Slack](https://www.slack.com)
 
-The target for a Slack subscription will be the channel name (including the `#`, for example `#channel`). You can optionally suffix the channel name with `!` and that will cause the alerts to include a `@channel` mention (for example `#channel!`).
+The target for a Slack subscription will be the channel name (e.g. `#channel` or `@channel`).
 
-* `SLACK_TOKEN` - The Slack api auth token. Default: ``
+* `SLACK_WEBHOOK_URL` - The Slack webhook URL. Default: ``
 * `SLACK_USERNAME` - The username that messages will be sent to slack. Default: `Seyren`
 * `SLACK_ICON_URL` - The user icon URL. Default: ``
 * `SLACK_EMOJIS` - Mapping between state and emojis unicode. Default: ``

--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ To generate a "Service API Key", see [PagerDuty Support: Adding Services](https:
 
 ##### [Slack](https://www.slack.com)
 
-The target for a Slack subscription will be the channel name (including the `#`, for example `#channel`). You can optionally suffix the channel name with `!` and that will cause the alerts to include a `@channel` mention (for example `#channel!`).
+You can specify either `SLACK_TOKEN` (which will be evaluated first for compatibility reason) or `SLACK_WEBHOOK_URL` (which should be the preferred method).
+If you set `SLACK_TOKEN`, the target for a Slack subscription will be the channel name (including the `#`, for example `#channel`). You can optionally suffix the channel name with `!` and that will cause the alerts to include a `@channel` mention (for example `#channel!`). If you set `SLACK_WEBHOOK_URL`, you don't need to suffix the channel, you can simply use `#channel` or `@channel`.
 
 * `SLACK_TOKEN` - The Slack api auth token. Default: ``
+* `SLACK_WEBHOOK_URL` - The Slack webhook URL. Default: ``
 * `SLACK_USERNAME` - The username that messages will be sent to slack. Default: `Seyren`
 * `SLACK_ICON_URL` - The user icon URL. Default: ``
 * `SLACK_EMOJIS` - Mapping between state and emojis unicode. Default: ``

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ To generate a "Service API Key", see [PagerDuty Support: Adding Services](https:
 
 ##### [Slack](https://www.slack.com)
 
-The target for a Slack subscription will be the channel name (e.g. `#channel` or `@channel`).
+The target for a Slack subscription will be the channel name (including the `#`, for example `#channel`). You can optionally suffix the channel name with `!` and that will cause the alerts to include a `@channel` mention (for example `#channel!`).
 
-* `SLACK_WEBHOOK_URL` - The Slack webhook URL. Default: ``
+* `SLACK_TOKEN` - The Slack api auth token. Default: ``
 * `SLACK_USERNAME` - The username that messages will be sent to slack. Default: `Seyren`
 * `SLACK_ICON_URL` - The user icon URL. Default: ``
 * `SLACK_EMOJIS` - Mapping between state and emojis unicode. Default: ``

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
@@ -13,11 +13,11 @@
  */
 package com.seyren.core.service.notification;
 
-import static com.google.common.collect.Iterables.*;
+import static com.google.common.collect.Iterables.transform;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -25,15 +25,17 @@ import javax.inject.Named;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -51,50 +53,33 @@ public class SlackNotificationService implements NotificationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SlackNotificationService.class);
 
     private final SeyrenConfig seyrenConfig;
-    private final String baseUrl;
 
     @Inject
     public SlackNotificationService(SeyrenConfig seyrenConfig) {
         this.seyrenConfig = seyrenConfig;
-        this.baseUrl = "https://slack.com";
-    }
-
-    protected SlackNotificationService(SeyrenConfig seyrenConfig, String baseUrl) {
-        this.seyrenConfig = seyrenConfig;
-        this.baseUrl = baseUrl;
     }
 
     @Override
     public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
-        String token = seyrenConfig.getSlackToken();
-        String channel = subscription.getTarget();
-        String username = seyrenConfig.getSlackUsername();
-        String iconUrl = seyrenConfig.getSlackIconUrl();
+        String webhookUrl = seyrenConfig.getSlackWebhook();
 
         List<String> emojis = Lists.newArrayList(
                 Splitter.on(',').omitEmptyStrings().trimResults().split(seyrenConfig.getSlackEmojis())
         );
 
-        String url = String.format("%s/api/chat.postMessage", baseUrl);
         HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
-        HttpPost post = new HttpPost(url);
+        HttpPost post = new HttpPost(webhookUrl);
         post.addHeader("accept", "application/json");
 
-        List<BasicNameValuePair> parameters = new ArrayList<BasicNameValuePair>();
-        parameters.add(new BasicNameValuePair("token", token));
-        parameters.add(new BasicNameValuePair("channel", StringUtils.removeEnd(channel, "!")));
-        parameters.add(new BasicNameValuePair("text", formatContent(emojis, check, subscription, alerts)));
-        parameters.add(new BasicNameValuePair("username", username));
-        parameters.add(new BasicNameValuePair("icon_url", iconUrl));
-
         try {
-            post.setEntity(new UrlEncodedFormEntity(parameters));
+            String message = generateMessage(emojis, check, subscription, alerts);
+            post.setEntity(new StringEntity(message, ContentType.APPLICATION_JSON));
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.info("> parameters: {}", parameters);
+                LOGGER.info("> message: {}", message);
             }
             HttpResponse response = client.execute(post);
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.info("> parameters: {}", parameters);
+                LOGGER.info("> message: {}", message);
                 LOGGER.debug("Status: {}, Body: {}", response.getStatusLine(), new BasicResponseHandler().handleResponse(response));
             }
         } catch (Exception e) {
@@ -111,6 +96,17 @@ public class SlackNotificationService implements NotificationService {
         return subscriptionType == SubscriptionType.SLACK;
     }
 
+    private String generateMessage(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) throws JsonProcessingException {
+	Map<String,String> payload = new HashMap<String, String>();
+	payload.put("channel", subscription.getTarget());
+	payload.put("username", seyrenConfig.getSlackUsername());
+	payload.put("text", formatContent(emojis, check, subscription, alerts));
+	payload.put("icon_url", seyrenConfig.getSlackIconUrl());
+
+	String message = new ObjectMapper().writeValueAsString(payload);
+	return message;
+    }
+
     private String formatContent(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) {
         String url = String.format("%s/#/checks/%s", seyrenConfig.getBaseUrl(), check.getId());
         String alertsString = Joiner.on("\n").join(transform(alerts, new Function<Alert, String>() {
@@ -119,8 +115,6 @@ public class SlackNotificationService implements NotificationService {
                 return String.format("%s = %s (%s to %s)", input.getTarget(), input.getValue().toString(), input.getFromType(), input.getToType());
             }
         }));
-
-        String channel = subscription.getTarget().contains("!") ? "<!channel>" : "";
 
         String description;
         if (StringUtils.isNotBlank(check.getDescription())) {
@@ -131,15 +125,13 @@ public class SlackNotificationService implements NotificationService {
 
         final String state = check.getState().toString();
 
-        return String.format("%s*%s* %s [%s]%s\n```\n%s\n```\n#%s %s",
+        return String.format("%s *%s* %s (<%s|Open>)%s\n```\n%s\n```",
                 Iterables.get(emojis, check.getState().ordinal(), ""),
                 state,
                 check.getName(),
                 url,
                 description,
-                alertsString,
-                state.toLowerCase(Locale.getDefault()),
-                channel
+                alertsString
         );
     }
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/SlackNotificationService.java
@@ -13,11 +13,13 @@
  */
 package com.seyren.core.service.notification;
 
-import static com.google.common.collect.Iterables.*;
+import static com.google.common.collect.Iterables.transform;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -28,12 +30,16 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -65,69 +71,74 @@ public class SlackNotificationService implements NotificationService {
     }
 
     @Override
-    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
-        String token = seyrenConfig.getSlackToken();
-        String channel = subscription.getTarget();
-        String username = seyrenConfig.getSlackUsername();
-        String iconUrl = seyrenConfig.getSlackIconUrl();
-
-        List<String> emojis = Lists.newArrayList(
-                Splitter.on(',').omitEmptyStrings().trimResults().split(seyrenConfig.getSlackEmojis())
-        );
-
-        String url = String.format("%s/api/chat.postMessage", baseUrl);
-        HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
-        HttpPost post = new HttpPost(url);
-        post.addHeader("accept", "application/json");
-
-        List<BasicNameValuePair> parameters = new ArrayList<BasicNameValuePair>();
-        parameters.add(new BasicNameValuePair("token", token));
-        parameters.add(new BasicNameValuePair("channel", StringUtils.removeEnd(channel, "!")));
-        parameters.add(new BasicNameValuePair("text", formatContent(emojis, check, subscription, alerts)));
-        parameters.add(new BasicNameValuePair("username", username));
-        parameters.add(new BasicNameValuePair("icon_url", iconUrl));
-
-        try {
-            post.setEntity(new UrlEncodedFormEntity(parameters));
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.info("> parameters: {}", parameters);
-            }
-            HttpResponse response = client.execute(post);
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.info("> parameters: {}", parameters);
-                LOGGER.debug("Status: {}, Body: {}", response.getStatusLine(), new BasicResponseHandler().handleResponse(response));
-            }
-        } catch (Exception e) {
-            LOGGER.warn("Error posting to Slack", e);
-        } finally {
-            post.releaseConnection();
-            HttpClientUtils.closeQuietly(client);
-        }
-
-    }
-
-    @Override
     public boolean canHandle(SubscriptionType subscriptionType) {
         return subscriptionType == SubscriptionType.SLACK;
     }
 
+    @Override
+    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+        if ( !seyrenConfig.getSlackToken().isEmpty() ) {
+            LOGGER.info("Will use API token");
+            notifyUsingApiToken(check, subscription, alerts);
+        }
+        else if ( !seyrenConfig.getSlackWebhook().isEmpty() ) {
+            LOGGER.info("Will use Webhook");
+            notifyUsingWebhook(check, subscription, alerts);
+        }
+        else
+          LOGGER.warn("Slack token and Slack Webhook are empty. Do nothing.");
+    }
+
+    //
+    // API Test Token. You should really switch to Webhook.
+    // Just copied previous code.
+    //
+
+    private void notifyUsingApiToken(Check check, Subscription subscription, List<Alert> alerts) {
+      String token = seyrenConfig.getSlackToken();
+      String channel = subscription.getTarget();
+      String username = seyrenConfig.getSlackUsername();
+      String iconUrl = seyrenConfig.getSlackIconUrl();
+
+      List<String> emojis = extractEmojis();
+
+      String url = String.format("%s/api/chat.postMessage", baseUrl);
+      HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
+      HttpPost post = new HttpPost(url);
+      post.addHeader("accept", "application/json");
+
+      List<BasicNameValuePair> parameters = new ArrayList<BasicNameValuePair>();
+      parameters.add(new BasicNameValuePair("token", token));
+      parameters.add(new BasicNameValuePair("channel", StringUtils.removeEnd(channel, "!")));
+      parameters.add(new BasicNameValuePair("text", formatContent(emojis, check, subscription, alerts)));
+      parameters.add(new BasicNameValuePair("username", username));
+      parameters.add(new BasicNameValuePair("icon_url", iconUrl));
+
+      try {
+          post.setEntity(new UrlEncodedFormEntity(parameters));
+          if (LOGGER.isDebugEnabled()) {
+              LOGGER.info("> parameters: {}", parameters);
+          }
+          HttpResponse response = client.execute(post);
+          if (LOGGER.isDebugEnabled()) {
+              LOGGER.info("> parameters: {}", parameters);
+              LOGGER.debug("Status: {}, Body: {}", response.getStatusLine(), new BasicResponseHandler().handleResponse(response));
+          }
+      } catch (Exception e) {
+          LOGGER.warn("Error posting to Slack", e);
+      } finally {
+          post.releaseConnection();
+          HttpClientUtils.closeQuietly(client);
+      }
+    }
+
     private String formatContent(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) {
-        String url = String.format("%s/#/checks/%s", seyrenConfig.getBaseUrl(), check.getId());
-        String alertsString = Joiner.on("\n").join(transform(alerts, new Function<Alert, String>() {
-            @Override
-            public String apply(Alert input) {
-                return String.format("%s = %s (%s to %s)", input.getTarget(), input.getValue().toString(), input.getFromType(), input.getToType());
-            }
-        }));
+        String url = formatCheckUrl(check);
+        String alertsString = formatAlert(alerts);
 
         String channel = subscription.getTarget().contains("!") ? "<!channel>" : "";
 
-        String description;
-        if (StringUtils.isNotBlank(check.getDescription())) {
-            description = String.format("\n> %s", check.getDescription());
-        } else {
-            description = "";
-        }
+        String description = formatDescription(check);
 
         final String state = check.getState().toString();
 
@@ -140,6 +151,99 @@ public class SlackNotificationService implements NotificationService {
                 alertsString,
                 state.toLowerCase(Locale.getDefault()),
                 channel
+        );
+    }
+
+    private List<String> extractEmojis() {
+      List<String> emojis = Lists.newArrayList(
+              Splitter.on(',').omitEmptyStrings().trimResults().split(seyrenConfig.getSlackEmojis())
+      );
+      return emojis;
+    }
+
+    private String formatCheckUrl(Check check) {
+      String url = String.format("%s/#/checks/%s", seyrenConfig.getBaseUrl(), check.getId());
+      return url;
+    }
+
+    private String formatAlert(List<Alert> alerts) {
+      String alertsString = Joiner.on("\n").join(transform(alerts, new Function<Alert, String>() {
+          @Override
+          public String apply(Alert input) {
+              return String.format("%s = %s (%s to %s)", input.getTarget(), input.getValue().toString(), input.getFromType(), input.getToType());
+          }
+      }));
+      return alertsString;
+    }
+
+    private String formatDescription(Check check) {
+      String description;
+      if (StringUtils.isNotBlank(check.getDescription())) {
+          description = String.format("\n> %s", check.getDescription());
+      } else {
+          description = "";
+      }
+      return description;
+    }
+
+    //
+    // Webhook
+    //
+
+    private void notifyUsingWebhook(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+        String webhookUrl = seyrenConfig.getSlackWebhook();
+
+        List<String> emojis = extractEmojis();
+
+        HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
+        HttpPost post = new HttpPost(webhookUrl);
+        post.addHeader("accept", "application/json");
+
+        try {
+            String message = generateMessage(emojis, check, subscription, alerts);
+            post.setEntity(new StringEntity(message, ContentType.APPLICATION_JSON));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.info("> message: {}", message);
+            }
+            HttpResponse response = client.execute(post);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.info("> message: {}", message);
+                LOGGER.debug("Status: {}, Body: {}", response.getStatusLine(), new BasicResponseHandler().handleResponse(response));
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Error posting to Slack", e);
+        } finally {
+            post.releaseConnection();
+            HttpClientUtils.closeQuietly(client);
+        }
+    }
+
+    private String generateMessage(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) throws JsonProcessingException {
+        Map<String,String> payload = new HashMap<String, String>();
+        payload.put("channel", subscription.getTarget());
+        payload.put("username", seyrenConfig.getSlackUsername());
+        payload.put("text", formatText(emojis, check, subscription, alerts));
+        payload.put("icon_url", seyrenConfig.getSlackIconUrl());
+
+        String message = new ObjectMapper().writeValueAsString(payload);
+        return message;
+    }
+
+    private String formatText(List<String> emojis, Check check, Subscription subscription, List<Alert> alerts) {
+        String url = formatCheckUrl(check);
+        String alertsString = formatAlert(alerts);
+
+        String description = formatDescription(check);
+
+        final String state = check.getState().toString();
+
+        return String.format("%s *%s* %s (<%s|Open>)%s\n```\n%s\n```",
+                Iterables.get(emojis, check.getState().ordinal(), ""),
+                state,
+                check.getName(),
+                url,
+                description,
+                alertsString
         );
     }
 }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -70,7 +70,7 @@ public class SeyrenConfig {
     private final String flowdockEmojis;
     private final String ircCatHost;
     private final String ircCatPort;
-    private final String slackWebhook;
+    private final String slackToken;
     private final String slackUsername;
     private final String slackIconUrl;
     private final String slackEmojis;
@@ -145,7 +145,7 @@ public class SeyrenConfig {
         this.ircCatPort = configOrDefault("IRCCAT_PORT", "12345");
 
         // Slack
-        this.slackWebhook = configOrDefault("SLACK_WEBHOOK_URL", "");
+        this.slackToken = configOrDefault("SLACK_TOKEN", "");
         this.slackUsername = configOrDefault("SLACK_USERNAME", "Seyren");
         this.slackIconUrl = configOrDefault("SLACK_ICON_URL", "");
         this.slackEmojis = configOrDefault("SLACK_EMOJIS", "");
@@ -392,8 +392,8 @@ public class SeyrenConfig {
     }
 
     @JsonIgnore
-    public String getSlackWebhook() {
-      return slackWebhook;
+    public String getSlackToken() {
+      return slackToken;
     }
 
     @JsonIgnore

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -71,6 +71,7 @@ public class SeyrenConfig {
     private final String ircCatHost;
     private final String ircCatPort;
     private final String slackToken;
+    private final String slackWebhook;
     private final String slackUsername;
     private final String slackIconUrl;
     private final String slackEmojis;
@@ -146,6 +147,7 @@ public class SeyrenConfig {
 
         // Slack
         this.slackToken = configOrDefault("SLACK_TOKEN", "");
+        this.slackWebhook = configOrDefault("SLACK_WEBHOOK_URL", "");
         this.slackUsername = configOrDefault("SLACK_USERNAME", "Seyren");
         this.slackIconUrl = configOrDefault("SLACK_ICON_URL", "");
         this.slackEmojis = configOrDefault("SLACK_EMOJIS", "");
@@ -394,6 +396,11 @@ public class SeyrenConfig {
     @JsonIgnore
     public String getSlackToken() {
       return slackToken;
+    }
+
+    @JsonIgnore
+    public String getSlackWebhook() {
+      return slackWebhook;
     }
 
     @JsonIgnore

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -70,7 +70,7 @@ public class SeyrenConfig {
     private final String flowdockEmojis;
     private final String ircCatHost;
     private final String ircCatPort;
-    private final String slackToken;
+    private final String slackWebhook;
     private final String slackUsername;
     private final String slackIconUrl;
     private final String slackEmojis;
@@ -145,7 +145,7 @@ public class SeyrenConfig {
         this.ircCatPort = configOrDefault("IRCCAT_PORT", "12345");
 
         // Slack
-        this.slackToken = configOrDefault("SLACK_TOKEN", "");
+        this.slackWebhook = configOrDefault("SLACK_WEBHOOK_URL", "");
         this.slackUsername = configOrDefault("SLACK_USERNAME", "Seyren");
         this.slackIconUrl = configOrDefault("SLACK_ICON_URL", "");
         this.slackEmojis = configOrDefault("SLACK_EMOJIS", "");
@@ -392,8 +392,8 @@ public class SeyrenConfig {
     }
 
     @JsonIgnore
-    public String getSlackToken() {
-      return slackToken;
+    public String getSlackWebhook() {
+      return slackWebhook;
     }
 
     @JsonIgnore

--- a/seyren-core/src/test/java/com/seyren/core/service/notification/SlackNotificationServiceTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/notification/SlackNotificationServiceTest.java
@@ -13,17 +13,20 @@
  */
 package com.seyren.core.service.notification;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.UnsupportedEncodingException;
+import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
@@ -32,6 +35,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.restdriver.clientdriver.ClientDriverRequest;
 import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.github.restdriver.clientdriver.capture.StringBodyCapture;
@@ -43,6 +50,9 @@ import com.seyren.core.domain.SubscriptionType;
 import com.seyren.core.util.config.SeyrenConfig;
 
 public class SlackNotificationServiceTest {
+    private static final String USERNAME = "Seyren";
+    private static final String SLACK_URI_TO_POST = "/services/SOMETHING/ANOTHERTHING/FINALTHING";
+
     private NotificationService notificationService;
     private SeyrenConfig mockSeyrenConfig;
 
@@ -53,11 +63,11 @@ public class SlackNotificationServiceTest {
     public void before() {
         mockSeyrenConfig = mock(SeyrenConfig.class);
         when(mockSeyrenConfig.getBaseUrl()).thenReturn(clientDriver.getBaseUrl() + "/slack");
+        when(mockSeyrenConfig.getSlackWebhook()).thenReturn(clientDriver.getBaseUrl() + SLACK_URI_TO_POST);
         when(mockSeyrenConfig.getSlackEmojis()).thenReturn("");
         when(mockSeyrenConfig.getSlackIconUrl()).thenReturn("");
-        when(mockSeyrenConfig.getSlackToken()).thenReturn("");
-        when(mockSeyrenConfig.getSlackUsername()).thenReturn("Seyren");
-        notificationService = new SlackNotificationService(mockSeyrenConfig, clientDriver.getBaseUrl());
+        when(mockSeyrenConfig.getSlackUsername()).thenReturn(USERNAME);
+        notificationService = new SlackNotificationService(mockSeyrenConfig);
     }
 
     @After
@@ -77,117 +87,73 @@ public class SlackNotificationServiceTest {
     }
 
     @Test
-    public void basicSlackTest() {
-        BigDecimal value = new BigDecimal("1.0");
+    public void basicSlackTest() throws JsonParseException, JsonMappingException, IOException {
+	// Given
+        Check check = givenCheck();
 
+        Subscription subscription = givenSubsciption();
+
+        Alert alert = givenAlert();
+        List<Alert> alerts = Arrays.asList(alert);
+
+        StringBodyCapture bodyCapture = new StringBodyCapture();
+
+        clientDriver.addExpectation(
+                onRequestTo(SLACK_URI_TO_POST)
+                        .withMethod(ClientDriverRequest.Method.POST)
+                        .capturingBodyIn(bodyCapture)
+                        .withHeader("accept", "application/json"),
+                giveEmptyResponse());
+
+        // When
+        notificationService.sendNotification(check, subscription, alerts);
+
+        // Then
+        String content = bodyCapture.getContent();
+
+        Map<String,String> map = new HashMap<String,String>();
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+        map = mapper.readValue(content, typeRef);
+
+        assertThat(map.get("channel"), Matchers.is(subscription.getTarget()));
+        assertThat(map.get("text"), Matchers.containsString("*" + check.getState().name() + "* "));
+        assertThat(map.get("text"), Matchers.containsString("/#/checks/" + check.getId()));
+        assertThat(map.get("text"), Matchers.containsString(check.getName()));
+        assertThat(map.get("username"), Matchers.is(USERNAME));
+        assertThat(map.get("icon_url"), Matchers.isEmptyString());
+
+        verify(mockSeyrenConfig).getSlackWebhook();
+        verify(mockSeyrenConfig).getSlackEmojis();
+        verify(mockSeyrenConfig).getSlackIconUrl();
+        verify(mockSeyrenConfig).getSlackUsername();
+        verify(mockSeyrenConfig).getBaseUrl();
+    }
+
+    Check givenCheck() {
         Check check = new Check()
                 .withId("123")
                 .withEnabled(true)
                 .withName("test-check")
                 .withState(AlertType.ERROR);
-        Subscription subscription = new Subscription()
+        return check;
+    }
+
+    Subscription givenSubsciption() {
+	Subscription subscription = new Subscription()
                 .withEnabled(true)
                 .withType(SubscriptionType.SLACK)
                 .withTarget("target");
-        Alert alert = new Alert()
-                .withValue(value)
+	return subscription;
+    }
+
+    Alert givenAlert() {
+	Alert alert = new Alert()
+                .withValue(new BigDecimal("1.0"))
                 .withTimestamp(new DateTime())
                 .withFromType(AlertType.OK)
                 .withToType(AlertType.ERROR);
-        List<Alert> alerts = Arrays.asList(alert);
-
-        StringBodyCapture bodyCapture = new StringBodyCapture();
-
-        clientDriver.addExpectation(
-                onRequestTo("/api/chat.postMessage")
-                        .withMethod(ClientDriverRequest.Method.POST)
-                        .capturingBodyIn(bodyCapture)
-                        .withHeader("accept", "application/json"),
-                giveEmptyResponse());
-
-        notificationService.sendNotification(check, subscription, alerts);
-
-        String content = bodyCapture.getContent();
-        System.out.println(decode(content));
-
-        assertThat(content, Matchers.containsString("token="));
-        assertThat(content, Matchers.containsString("&channel=target"));
-        assertThat(content, not(Matchers.containsString(encode("<!channel>"))));
-        assertThat(content, Matchers.containsString(encode("*ERROR* test-check")));
-        assertThat(content, Matchers.containsString(encode("/#/checks/123")));
-        assertThat(content, Matchers.containsString("&username=Seyren"));
-        assertThat(content, Matchers.containsString("&icon_url="));
-
-        verify(mockSeyrenConfig).getSlackEmojis();
-        verify(mockSeyrenConfig).getSlackIconUrl();
-        verify(mockSeyrenConfig).getSlackToken();
-        verify(mockSeyrenConfig).getSlackUsername();
-        verify(mockSeyrenConfig).getBaseUrl();
-    }
-
-    @Test
-    public void mentionChannelWhenTargetContainsExclamationTest() {
-        BigDecimal value = new BigDecimal("1.0");
-
-        Check check = new Check()
-                .withId("123")
-                .withEnabled(true)
-                .withName("test-check")
-                .withState(AlertType.ERROR);
-        Subscription subscription = new Subscription()
-                .withEnabled(true)
-                .withType(SubscriptionType.SLACK)
-                .withTarget("target!");
-        Alert alert = new Alert()
-                .withValue(value)
-                .withTimestamp(new DateTime())
-                .withFromType(AlertType.OK)
-                .withToType(AlertType.ERROR);
-        List<Alert> alerts = Arrays.asList(alert);
-
-        StringBodyCapture bodyCapture = new StringBodyCapture();
-
-        clientDriver.addExpectation(
-                onRequestTo("/api/chat.postMessage")
-                        .withMethod(ClientDriverRequest.Method.POST)
-                        .capturingBodyIn(bodyCapture)
-                        .withHeader("accept", "application/json"),
-                giveEmptyResponse());
-
-        notificationService.sendNotification(check, subscription, alerts);
-
-        String content = bodyCapture.getContent();
-        System.out.println(decode(content));
-
-        assertThat(content, Matchers.containsString("token="));
-        assertThat(content, Matchers.containsString("&channel=target"));
-        assertThat(content, Matchers.containsString(encode("<!channel>")));
-        assertThat(content, Matchers.containsString(encode("*ERROR* test-check")));
-        assertThat(content, Matchers.containsString(encode("/#/checks/123")));
-        assertThat(content, Matchers.containsString("&username=Seyren"));
-        assertThat(content, Matchers.containsString("&icon_url="));
-
-        verify(mockSeyrenConfig).getSlackEmojis();
-        verify(mockSeyrenConfig).getSlackIconUrl();
-        verify(mockSeyrenConfig).getSlackToken();
-        verify(mockSeyrenConfig).getSlackUsername();
-        verify(mockSeyrenConfig).getBaseUrl();
-    }
-
-    String encode(String data) {
-        try {
-            return URLEncoder.encode(data, "ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            return null;
-        }
-    }
-
-    String decode(String data) {
-        try {
-            return URLDecoder.decode(data, "ISO-8859-1");
-        } catch (UnsupportedEncodingException e) {
-            return null;
-        }
+	return alert;
     }
 
 }

--- a/seyren-core/src/test/java/com/seyren/core/service/notification/SlackNotificationServiceTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/notification/SlackNotificationServiceTest.java
@@ -13,10 +13,15 @@
  */
 package com.seyren.core.service.notification;
 
-import static com.github.restdriver.clientdriver.RestClientDriver.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -25,7 +30,7 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
 
-import org.hamcrest.Matchers;
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -43,6 +48,9 @@ import com.seyren.core.domain.SubscriptionType;
 import com.seyren.core.util.config.SeyrenConfig;
 
 public class SlackNotificationServiceTest {
+    private static final String USERNAME = "Seyren";
+    private static final String CONTENT_ENCODING = "ISO-8859-1";
+
     private NotificationService notificationService;
     private SeyrenConfig mockSeyrenConfig;
 
@@ -56,7 +64,7 @@ public class SlackNotificationServiceTest {
         when(mockSeyrenConfig.getSlackEmojis()).thenReturn("");
         when(mockSeyrenConfig.getSlackIconUrl()).thenReturn("");
         when(mockSeyrenConfig.getSlackToken()).thenReturn("");
-        when(mockSeyrenConfig.getSlackUsername()).thenReturn("Seyren");
+        when(mockSeyrenConfig.getSlackUsername()).thenReturn(USERNAME);
         notificationService = new SlackNotificationService(mockSeyrenConfig, clientDriver.getBaseUrl());
     }
 
@@ -66,7 +74,7 @@ public class SlackNotificationServiceTest {
     }
 
     @Test
-    public void notifcationServiceCanOnlyHandleSlackSubscription() {
+    public void notificationServiceCanOnlyHandleSlackSubscription() {
         assertThat(notificationService.canHandle(SubscriptionType.SLACK), is(true));
         for (SubscriptionType type : SubscriptionType.values()) {
             if (type == SubscriptionType.SLACK) {
@@ -78,22 +86,11 @@ public class SlackNotificationServiceTest {
 
     @Test
     public void basicSlackTest() {
-        BigDecimal value = new BigDecimal("1.0");
+        // Given
+        Check check = givenCheck();
+        Subscription subscription = givenSlackSubscriptionWithTarget("target");
+        Alert alert = givenAlert();
 
-        Check check = new Check()
-                .withId("123")
-                .withEnabled(true)
-                .withName("test-check")
-                .withState(AlertType.ERROR);
-        Subscription subscription = new Subscription()
-                .withEnabled(true)
-                .withType(SubscriptionType.SLACK)
-                .withTarget("target");
-        Alert alert = new Alert()
-                .withValue(value)
-                .withTimestamp(new DateTime())
-                .withFromType(AlertType.OK)
-                .withToType(AlertType.ERROR);
         List<Alert> alerts = Arrays.asList(alert);
 
         StringBodyCapture bodyCapture = new StringBodyCapture();
@@ -105,18 +102,16 @@ public class SlackNotificationServiceTest {
                         .withHeader("accept", "application/json"),
                 giveEmptyResponse());
 
+        // When
         notificationService.sendNotification(check, subscription, alerts);
 
+        // Then
         String content = bodyCapture.getContent();
         System.out.println(decode(content));
 
-        assertThat(content, Matchers.containsString("token="));
-        assertThat(content, Matchers.containsString("&channel=target"));
-        assertThat(content, not(Matchers.containsString(encode("<!channel>"))));
-        assertThat(content, Matchers.containsString(encode("*ERROR* test-check")));
-        assertThat(content, Matchers.containsString(encode("/#/checks/123")));
-        assertThat(content, Matchers.containsString("&username=Seyren"));
-        assertThat(content, Matchers.containsString("&icon_url="));
+        assertContent(content, check, subscription);
+        assertThat(content, containsString("&channel=" + subscription.getTarget()));
+        assertThat(content, not(containsString(encode("<!channel>"))));
 
         verify(mockSeyrenConfig).getSlackEmojis();
         verify(mockSeyrenConfig).getSlackIconUrl();
@@ -127,22 +122,11 @@ public class SlackNotificationServiceTest {
 
     @Test
     public void mentionChannelWhenTargetContainsExclamationTest() {
-        BigDecimal value = new BigDecimal("1.0");
+        //Given
+        Check check = givenCheck();
+        Subscription subscription = givenSlackSubscriptionWithTarget("target!");
+        Alert alert = givenAlert();
 
-        Check check = new Check()
-                .withId("123")
-                .withEnabled(true)
-                .withName("test-check")
-                .withState(AlertType.ERROR);
-        Subscription subscription = new Subscription()
-                .withEnabled(true)
-                .withType(SubscriptionType.SLACK)
-                .withTarget("target!");
-        Alert alert = new Alert()
-                .withValue(value)
-                .withTimestamp(new DateTime())
-                .withFromType(AlertType.OK)
-                .withToType(AlertType.ERROR);
         List<Alert> alerts = Arrays.asList(alert);
 
         StringBodyCapture bodyCapture = new StringBodyCapture();
@@ -154,18 +138,16 @@ public class SlackNotificationServiceTest {
                         .withHeader("accept", "application/json"),
                 giveEmptyResponse());
 
+        // When
         notificationService.sendNotification(check, subscription, alerts);
 
+        // Then
         String content = bodyCapture.getContent();
         System.out.println(decode(content));
 
-        assertThat(content, Matchers.containsString("token="));
-        assertThat(content, Matchers.containsString("&channel=target"));
-        assertThat(content, Matchers.containsString(encode("<!channel>")));
-        assertThat(content, Matchers.containsString(encode("*ERROR* test-check")));
-        assertThat(content, Matchers.containsString(encode("/#/checks/123")));
-        assertThat(content, Matchers.containsString("&username=Seyren"));
-        assertThat(content, Matchers.containsString("&icon_url="));
+        assertContent(content, check, subscription);
+        assertThat(content, containsString("&channel=" + StringUtils.removeEnd(subscription.getTarget(), "!")));
+        assertThat(content, containsString(encode("<!channel>")));
 
         verify(mockSeyrenConfig).getSlackEmojis();
         verify(mockSeyrenConfig).getSlackIconUrl();
@@ -174,9 +156,43 @@ public class SlackNotificationServiceTest {
         verify(mockSeyrenConfig).getBaseUrl();
     }
 
+    Check givenCheck() {
+        Check check = new Check()
+                .withId("123")
+                .withEnabled(true)
+                .withName("test-check")
+                .withState(AlertType.ERROR);
+        return check;
+    }
+
+    Subscription givenSlackSubscriptionWithTarget(String target) {
+	Subscription subscription = new Subscription()
+                .withEnabled(true)
+                .withType(SubscriptionType.SLACK)
+                .withTarget(target);
+        return subscription;
+    }
+
+    Alert givenAlert() {
+        Alert alert = new Alert()
+                .withValue(new BigDecimal("1.0"))
+                .withTimestamp(new DateTime())
+                .withFromType(AlertType.OK)
+                .withToType(AlertType.ERROR);
+        return alert;
+    }
+
+    private void assertContent(String content, Check check, Subscription subscription) {
+      assertThat(content, containsString("token="));
+      assertThat(content, containsString(encode("*" + check.getState().name() + "* " + check.getName())));
+      assertThat(content, containsString(encode("/#/checks/" + check.getId())));
+      assertThat(content, containsString("&username=" + USERNAME));
+      assertThat(content, containsString("&icon_url="));
+    }
+
     String encode(String data) {
         try {
-            return URLEncoder.encode(data, "ISO-8859-1");
+            return URLEncoder.encode(data, CONTENT_ENCODING);
         } catch (UnsupportedEncodingException e) {
             return null;
         }
@@ -184,7 +200,7 @@ public class SlackNotificationServiceTest {
 
     String decode(String data) {
         try {
-            return URLDecoder.decode(data, "ISO-8859-1");
+            return URLDecoder.decode(data, CONTENT_ENCODING);
         } catch (UnsupportedEncodingException e) {
             return null;
         }


### PR DESCRIPTION
Should fix #376. We may change the message using [slack attachment](https://api.slack.com/docs/attachments) though.
