### PR TITLE
Support multiple graphite sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The target for a Slack subscription will be the channel name (including the `#`,
 * `SNMP_PORT` - The SNMP port. Default: `162`
 * `SNMP_COMMUNITY` - The SNMP  community. Default: `public`
 * `SNMP_OID` - The SNMP OID. Default: `1.3.6.1.4.1.32473.1`
+* `SNMP_SOURCE` - This is the ip from which trap is sent. Default: `localhost`
 
 ##### [TEMPLATE](http://en.wikipedia.org/wiki/Apache_Velocity)
 * `TEMPLATE_EMAIL_FILE_PATH` - The path to the velocity template used when emailing an alert. Seyren will first attempt to load from the class path, but will fall back to loading from the filesystem.  Default: `com/seyren/core/service/notification/email-template.vm"`

--- a/seyren-api/pom.xml
+++ b/seyren-api/pom.xml
@@ -30,6 +30,36 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.collections</groupId>
+            <artifactId>google-collections</artifactId>
+            <version>1.0</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.1.4.RELEASE</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.6</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.9</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/seyren-api/src/main/java/com/seyren/api/bean/ChartsBean.java
+++ b/seyren-api/src/main/java/com/seyren/api/bean/ChartsBean.java
@@ -48,21 +48,20 @@ public class ChartsBean implements ChartsResource {
         if (check == null) {
             return Response.status(Status.NOT_FOUND).build();
         }
-        
+
         String target = check.getTarget();
         
         if (hideThresholds) {
-            return getChart(target, width, height, from, to, null, null, hideLegend, hideAxes);
+            return getChart(check.getGraphiteSourceUrl(), target, width, height, from, to, null, null, hideLegend, hideAxes);
         } else {
-            return getChart(target, width, height, from, to, check.getWarn(), check.getError(), hideLegend, hideAxes);
+            return getChart(check.getGraphiteSourceUrl(), target, width, height, from, to, check.getWarn(), check.getError(), hideLegend, hideAxes);
         }
-        
     }
     
     @Override
-    public Response getCustomChart(String target, int width, int height, String from, String to, String warnThreshold, String errorThreshold, boolean hideLegend,
+    public Response getCustomChart(String target, String graphiteSourceUrl, int width, int height, String from, String to, String warnThreshold, String errorThreshold, boolean hideLegend,
             boolean hideAxes) {
-        
+
         BigDecimal warn;
         if (StringUtils.isEmpty(warnThreshold)) {
             warn = null;
@@ -77,11 +76,10 @@ public class ChartsBean implements ChartsResource {
             error = new BigDecimal(errorThreshold);
         }
         
-        return getChart(target, width, height, from, to, warn, error, hideLegend, hideAxes);
-        
+        return getChart(graphiteSourceUrl, target, width, height, from, to, warn, error, hideLegend, hideAxes);
     }
     
-    private Response getChart(String target, int width, int height, String from, String to, BigDecimal warnThreshold, BigDecimal errorThreshold, boolean hideLegend,
+    private Response getChart(String graphiteSource, String target, int width, int height, String from, String to, BigDecimal warnThreshold, BigDecimal errorThreshold, boolean hideLegend,
             boolean hideAxes) {
         
         LegendState legendState;
@@ -99,12 +97,10 @@ public class ChartsBean implements ChartsResource {
         }
         
         try {
-            byte[] bytes = graphiteHttpClient.getChart(target, width, height, from, to, legendState, axesState, warnThreshold, errorThreshold);
+            byte[] bytes = graphiteHttpClient.getChart(graphiteSource, target, width, height, from, to, legendState, axesState, warnThreshold, errorThreshold);
             return Response.ok(bytes, "image/png").build();
         } catch (Exception e) {
             return Response.serverError().build();
-        }
-        
+        }   
     }
-    
 }

--- a/seyren-api/src/main/java/com/seyren/api/jaxrs/ChartsResource.java
+++ b/seyren-api/src/main/java/com/seyren/api/jaxrs/ChartsResource.java
@@ -40,6 +40,7 @@ public interface ChartsResource {
     @Produces("image/png")
     @Path("/chart/{target}")
     Response getCustomChart(@PathParam("target") String target,
+            @QueryParam("graphiteSourceUrl") String graphiteSourceUrl,
             @QueryParam("width") @DefaultValue("1200") int width,
             @QueryParam("height") @DefaultValue("350") int height,
             @QueryParam("from") @DefaultValue("-24hours") String from,

--- a/seyren-core/pom.xml
+++ b/seyren-core/pom.xml
@@ -104,16 +104,16 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
         </dependency>
-<!--         <dependency>
+         <dependency>
         	<groupId>com.opsgenie.integration</groupId>
         	<artifactId>sdk</artifactId>
-    	</dependency> -->
-<!--        <dependency>
+    	</dependency> 
+        <dependency>
             <groupId>com.opsgenie.integration</groupId>
             <artifactId>sdk</artifactId>
             <version>2.2.0</version>
             <type>jar</type>
-        </dependency>-->
+        </dependency>
     </dependencies>
 	<repositories>
 	  <repository>

--- a/seyren-core/pom.xml
+++ b/seyren-core/pom.xml
@@ -104,10 +104,16 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
         </dependency>
-        <dependency>
+<!--         <dependency>
         	<groupId>com.opsgenie.integration</groupId>
         	<artifactId>sdk</artifactId>
-    	</dependency>
+    	</dependency> -->
+<!--        <dependency>
+            <groupId>com.opsgenie.integration</groupId>
+            <artifactId>sdk</artifactId>
+            <version>2.2.0</version>
+            <type>jar</type>
+        </dependency>-->
     </dependencies>
 	<repositories>
 	  <repository>

--- a/seyren-core/src/main/java/com/seyren/core/domain/Check.java
+++ b/seyren-core/src/main/java/com/seyren/core/domain/Check.java
@@ -51,6 +51,7 @@ public class Check {
     private AlertType state;
     private DateTime lastCheck;
     private List<Subscription> subscriptions = new ArrayList<Subscription>();
+    private String graphiteSourceUrl;
     
     public String getId() {
         return id;
@@ -239,4 +240,16 @@ public class Check {
         return this;
     }
     
+    public String getGraphiteSourceUrl() {
+        return graphiteSourceUrl;
+    }
+    
+    public void setGraphiteSourceUrl(String graphiteSourceUrl) {
+        this.graphiteSourceUrl = graphiteSourceUrl;
+    }
+    
+    public Check withGraphiteSourceUrl(String graphiteSourceUrl) {
+        setGraphiteSourceUrl(graphiteSourceUrl);
+        return this;
+    }
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/checker/GraphiteTargetChecker.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/checker/GraphiteTargetChecker.java
@@ -47,7 +47,8 @@ public class GraphiteTargetChecker implements TargetChecker {
         Map<String, Optional<BigDecimal>> targetValues = new HashMap<String, Optional<BigDecimal>>();
         
         try {
-            JsonNode node = graphiteHttpClient.getTargetJson(check.getTarget(), check.getFrom(), check.getUntil());
+            JsonNode node = graphiteHttpClient.getTargetJson(check.getGraphiteSourceUrl(), check.getTarget(), check.getFrom(), check.getUntil());
+            
             for (JsonNode metric : node) {
                 String target = metric.path("target").asText();
                 try {

--- a/seyren-core/src/main/java/com/seyren/core/service/live/server/PickleHandler.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/live/server/PickleHandler.java
@@ -54,6 +54,7 @@ public class PickleHandler implements Runnable {
     public PickleHandler(Socket socket, Executor executor, ChecksStore checksStore, CheckRunnerFactory checkRunnerFactory) {
         this.socket = socket;
         this.executor = executor;
+        this.executor = executor;
         this.checksStore = checksStore;
         this.checkRunnerFactory = checkRunnerFactory;
     }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/OpsGenieNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/OpsGenieNotificationService.java
@@ -11,105 +11,105 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.seyren.core.service.notification;
+// package com.seyren.core.service.notification;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.List;
+// import java.io.IOException;
+// import java.text.ParseException;
+// import java.util.List;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+// import javax.inject.Inject;
+// import javax.inject.Named;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
 
-import com.ifountain.opsgenie.client.OpsGenieClient;
-import com.ifountain.opsgenie.client.OpsGenieClientException;
-import com.ifountain.opsgenie.client.model.alert.CloseAlertRequest;
-import com.ifountain.opsgenie.client.model.alert.CloseAlertResponse;
-import com.ifountain.opsgenie.client.model.alert.CreateAlertRequest;
-import com.ifountain.opsgenie.client.model.alert.CreateAlertResponse;
-import com.ifountain.opsgenie.client.model.alert.ListAlertsRequest;
-import com.ifountain.opsgenie.client.model.alert.ListAlertsResponse;
-import com.seyren.core.domain.Alert;
-import com.seyren.core.domain.AlertType;
-import com.seyren.core.domain.Check;
-import com.seyren.core.domain.Subscription;
-import com.seyren.core.domain.SubscriptionType;
-import com.seyren.core.exception.NotificationFailedException;
-import com.seyren.core.util.config.SeyrenConfig;
+// import com.ifountain.opsgenie.client.OpsGenieClient;
+// import com.ifountain.opsgenie.client.OpsGenieClientException;
+// import com.ifountain.opsgenie.client.model.alert.CloseAlertRequest;
+// import com.ifountain.opsgenie.client.model.alert.CloseAlertResponse;
+// import com.ifountain.opsgenie.client.model.alert.CreateAlertRequest;
+// import com.ifountain.opsgenie.client.model.alert.CreateAlertResponse;
+// import com.ifountain.opsgenie.client.model.alert.ListAlertsRequest;
+// import com.ifountain.opsgenie.client.model.alert.ListAlertsResponse;
+// import com.seyren.core.domain.Alert;
+// import com.seyren.core.domain.AlertType;
+// import com.seyren.core.domain.Check;
+// import com.seyren.core.domain.Subscription;
+// import com.seyren.core.domain.SubscriptionType;
+// import com.seyren.core.exception.NotificationFailedException;
+// import com.seyren.core.util.config.SeyrenConfig;
 
-@Named
-public class OpsGenieNotificationService implements NotificationService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpsGenieNotificationService.class);
-	private SeyrenConfig config;
+// @Named
+// public class OpsGenieNotificationService implements NotificationService {
+//     private static final Logger LOGGER = LoggerFactory.getLogger(OpsGenieNotificationService.class);
+// 	private SeyrenConfig config;
 
-    @Inject
-    public OpsGenieNotificationService(SeyrenConfig config) {
-    	this.config = config;
-    }
+//     @Inject
+//     public OpsGenieNotificationService(SeyrenConfig config) {
+//     	this.config = config;
+//     }
     
-    @Override
-    public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
-    	OpsGenieClient client = new OpsGenieClient();
+//     @Override
+//     public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+//     	OpsGenieClient client = new OpsGenieClient();
 
-        try {
-            String apiKey = subscription.getTarget();
-			if (check.getState() == AlertType.ERROR || check.getState() == AlertType.WARN) {
-		    	CreateAlertRequest request = new CreateAlertRequest();
-		    	request.setApiKey(apiKey);
-		    	request.setMessage(getMessage(check));
-		    	request.setSource("Seyren");
-		    	request.setTeams(config.getOpsGenieTeams());
+//         try {
+//             String apiKey = subscription.getTarget();
+// 			if (check.getState() == AlertType.ERROR || check.getState() == AlertType.WARN) {
+// 		    	CreateAlertRequest request = new CreateAlertRequest();
+// 		    	request.setApiKey(apiKey);
+// 		    	request.setMessage(getMessage(check));
+// 		    	request.setSource("Seyren");
+// 		    	request.setTeams(config.getOpsGenieTeams());
 		
-		    	CreateAlertResponse response = client.alert().createAlert(request);
-		    	assert response.isSuccess();
-            } else if (check.getState() == AlertType.OK) {
-            	com.ifountain.opsgenie.client.model.beans.Alert alert = findAlert(client, apiKey, getMessage(check));
+// 		    	CreateAlertResponse response = client.alert().createAlert(request);
+// 		    	assert response.isSuccess();
+//             } else if (check.getState() == AlertType.OK) {
+//             	com.ifountain.opsgenie.client.model.beans.Alert alert = findAlert(client, apiKey, getMessage(check));
             
-            	CloseAlertRequest request = new CloseAlertRequest();
-            	request.setId(alert.getId());
-            	request.setApiKey(apiKey);
-            	CloseAlertResponse response = client.alert().closeAlert(request);
-            	assert response.isSuccess();
-            }
-		} catch (OpsGenieClientException e) {
-			LOGGER.warn(
-					"Did not send notification to OpsGenie for check in state: {}",
-					check.getState(), e);
-		} catch (IOException e) {
-			LOGGER.warn(
-					"Did not send notification to OpsGenie for check in state: {}",
-					check.getState(), e);
-		} catch (ParseException e) {
-			LOGGER.warn(
-					"Did not send notification to OpsGenie for check in state: {}",
-					check.getState(), e);
+//             	CloseAlertRequest request = new CloseAlertRequest();
+//             	request.setId(alert.getId());
+//             	request.setApiKey(apiKey);
+//             	CloseAlertResponse response = client.alert().closeAlert(request);
+//             	assert response.isSuccess();
+//             }
+// 		} catch (OpsGenieClientException e) {
+// 			LOGGER.warn(
+// 					"Did not send notification to OpsGenie for check in state: {}",
+// 					check.getState(), e);
+// 		} catch (IOException e) {
+// 			LOGGER.warn(
+// 					"Did not send notification to OpsGenie for check in state: {}",
+// 					check.getState(), e);
+// 		} catch (ParseException e) {
+// 			LOGGER.warn(
+// 					"Did not send notification to OpsGenie for check in state: {}",
+// 					check.getState(), e);
 
-		}
-    }
+// 		}
+//     }
 
-	private com.ifountain.opsgenie.client.model.beans.Alert findAlert(OpsGenieClient client, String apiKey, String message) throws OpsGenieClientException, IOException, ParseException {
-		ListAlertsRequest request = new ListAlertsRequest();
-		request.setApiKey(apiKey);
+// 	private com.ifountain.opsgenie.client.model.beans.Alert findAlert(OpsGenieClient client, String apiKey, String message) throws OpsGenieClientException, IOException, ParseException {
+// 		ListAlertsRequest request = new ListAlertsRequest();
+// 		request.setApiKey(apiKey);
 
-		ListAlertsResponse response = client.alert().listAlerts(request);
-		List<com.ifountain.opsgenie.client.model.beans.Alert> alerts = response.getAlerts();
-		for (com.ifountain.opsgenie.client.model.beans.Alert alert: alerts) {
-			if (alert.getMessage().equals(message)) {
-				return alert;
-			}
-		}
-		return null;
-	}
+// 		ListAlertsResponse response = client.alert().listAlerts(request);
+// 		List<com.ifountain.opsgenie.client.model.beans.Alert> alerts = response.getAlerts();
+// 		for (com.ifountain.opsgenie.client.model.beans.Alert alert: alerts) {
+// 			if (alert.getMessage().equals(message)) {
+// 				return alert;
+// 			}
+// 		}
+// 		return null;
+// 	}
 
-	private String getMessage(Check check) {
-		return "Check '" + check.getName() + "' has exceeded its threshold.";
-	}
+// 	private String getMessage(Check check) {
+// 		return "Check '" + check.getName() + "' has exceeded its threshold.";
+// 	}
 
-    @Override
-    public boolean canHandle(SubscriptionType subscriptionType) {
-        return subscriptionType == SubscriptionType.OPSGENIE;
-    }
+//     @Override
+//     public boolean canHandle(SubscriptionType subscriptionType) {
+//         return subscriptionType == SubscriptionType.OPSGENIE;
+//     }
 
-}
+// }

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/OpsGenieNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/OpsGenieNotificationService.java
@@ -11,105 +11,105 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// package com.seyren.core.service.notification;
+ package com.seyren.core.service.notification;
 
-// import java.io.IOException;
-// import java.text.ParseException;
-// import java.util.List;
+ import java.io.IOException;
+ import java.text.ParseException;
+ import java.util.List;
 
-// import javax.inject.Inject;
-// import javax.inject.Named;
+ import javax.inject.Inject;
+ import javax.inject.Named;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
 
-// import com.ifountain.opsgenie.client.OpsGenieClient;
-// import com.ifountain.opsgenie.client.OpsGenieClientException;
-// import com.ifountain.opsgenie.client.model.alert.CloseAlertRequest;
-// import com.ifountain.opsgenie.client.model.alert.CloseAlertResponse;
-// import com.ifountain.opsgenie.client.model.alert.CreateAlertRequest;
-// import com.ifountain.opsgenie.client.model.alert.CreateAlertResponse;
-// import com.ifountain.opsgenie.client.model.alert.ListAlertsRequest;
-// import com.ifountain.opsgenie.client.model.alert.ListAlertsResponse;
-// import com.seyren.core.domain.Alert;
-// import com.seyren.core.domain.AlertType;
-// import com.seyren.core.domain.Check;
-// import com.seyren.core.domain.Subscription;
-// import com.seyren.core.domain.SubscriptionType;
-// import com.seyren.core.exception.NotificationFailedException;
-// import com.seyren.core.util.config.SeyrenConfig;
+ import com.ifountain.opsgenie.client.OpsGenieClient;
+ import com.ifountain.opsgenie.client.OpsGenieClientException;
+ import com.ifountain.opsgenie.client.model.alert.CloseAlertRequest;
+ import com.ifountain.opsgenie.client.model.alert.CloseAlertResponse;
+ import com.ifountain.opsgenie.client.model.alert.CreateAlertRequest;
+ import com.ifountain.opsgenie.client.model.alert.CreateAlertResponse;
+ import com.ifountain.opsgenie.client.model.alert.ListAlertsRequest;
+ import com.ifountain.opsgenie.client.model.alert.ListAlertsResponse;
+ import com.seyren.core.domain.Alert;
+ import com.seyren.core.domain.AlertType;
+ import com.seyren.core.domain.Check;
+ import com.seyren.core.domain.Subscription;
+ import com.seyren.core.domain.SubscriptionType;
+ import com.seyren.core.exception.NotificationFailedException;
+ import com.seyren.core.util.config.SeyrenConfig;
 
-// @Named
-// public class OpsGenieNotificationService implements NotificationService {
-//     private static final Logger LOGGER = LoggerFactory.getLogger(OpsGenieNotificationService.class);
-// 	private SeyrenConfig config;
+ @Named
+ public class OpsGenieNotificationService implements NotificationService {
+     private static final Logger LOGGER = LoggerFactory.getLogger(OpsGenieNotificationService.class);
+ 	private SeyrenConfig config;
 
-//     @Inject
-//     public OpsGenieNotificationService(SeyrenConfig config) {
-//     	this.config = config;
-//     }
+     @Inject
+     public OpsGenieNotificationService(SeyrenConfig config) {
+     	this.config = config;
+     }
     
-//     @Override
-//     public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
-//     	OpsGenieClient client = new OpsGenieClient();
+     @Override
+     public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
+     	OpsGenieClient client = new OpsGenieClient();
 
-//         try {
-//             String apiKey = subscription.getTarget();
-// 			if (check.getState() == AlertType.ERROR || check.getState() == AlertType.WARN) {
-// 		    	CreateAlertRequest request = new CreateAlertRequest();
-// 		    	request.setApiKey(apiKey);
-// 		    	request.setMessage(getMessage(check));
-// 		    	request.setSource("Seyren");
-// 		    	request.setTeams(config.getOpsGenieTeams());
+         try {
+             String apiKey = subscription.getTarget();
+ 			if (check.getState() == AlertType.ERROR || check.getState() == AlertType.WARN) {
+ 		    	CreateAlertRequest request = new CreateAlertRequest();
+ 		    	request.setApiKey(apiKey);
+ 		    	request.setMessage(getMessage(check));
+ 		    	request.setSource("Seyren");
+ 		    	request.setTeams(config.getOpsGenieTeams());
 		
-// 		    	CreateAlertResponse response = client.alert().createAlert(request);
-// 		    	assert response.isSuccess();
-//             } else if (check.getState() == AlertType.OK) {
-//             	com.ifountain.opsgenie.client.model.beans.Alert alert = findAlert(client, apiKey, getMessage(check));
+ 		    	CreateAlertResponse response = client.alert().createAlert(request);
+ 		    	assert response.isSuccess();
+             } else if (check.getState() == AlertType.OK) {
+             	com.ifountain.opsgenie.client.model.beans.Alert alert = findAlert(client, apiKey, getMessage(check));
             
-//             	CloseAlertRequest request = new CloseAlertRequest();
-//             	request.setId(alert.getId());
-//             	request.setApiKey(apiKey);
-//             	CloseAlertResponse response = client.alert().closeAlert(request);
-//             	assert response.isSuccess();
-//             }
-// 		} catch (OpsGenieClientException e) {
-// 			LOGGER.warn(
-// 					"Did not send notification to OpsGenie for check in state: {}",
-// 					check.getState(), e);
-// 		} catch (IOException e) {
-// 			LOGGER.warn(
-// 					"Did not send notification to OpsGenie for check in state: {}",
-// 					check.getState(), e);
-// 		} catch (ParseException e) {
-// 			LOGGER.warn(
-// 					"Did not send notification to OpsGenie for check in state: {}",
-// 					check.getState(), e);
+             	CloseAlertRequest request = new CloseAlertRequest();
+             	request.setId(alert.getId());
+             	request.setApiKey(apiKey);
+             	CloseAlertResponse response = client.alert().closeAlert(request);
+             	assert response.isSuccess();
+             }
+ 		} catch (OpsGenieClientException e) {
+ 			LOGGER.warn(
+ 					"Did not send notification to OpsGenie for check in state: {}",
+ 					check.getState(), e);
+ 		} catch (IOException e) {
+ 			LOGGER.warn(
+ 					"Did not send notification to OpsGenie for check in state: {}",
+ 					check.getState(), e);
+ 		} catch (ParseException e) {
+ 			LOGGER.warn(
+ 					"Did not send notification to OpsGenie for check in state: {}",
+ 					check.getState(), e);
 
-// 		}
-//     }
+ 		}
+     }
 
-// 	private com.ifountain.opsgenie.client.model.beans.Alert findAlert(OpsGenieClient client, String apiKey, String message) throws OpsGenieClientException, IOException, ParseException {
-// 		ListAlertsRequest request = new ListAlertsRequest();
-// 		request.setApiKey(apiKey);
+ 	private com.ifountain.opsgenie.client.model.beans.Alert findAlert(OpsGenieClient client, String apiKey, String message) throws OpsGenieClientException, IOException, ParseException {
+ 		ListAlertsRequest request = new ListAlertsRequest();
+ 		request.setApiKey(apiKey);
 
-// 		ListAlertsResponse response = client.alert().listAlerts(request);
-// 		List<com.ifountain.opsgenie.client.model.beans.Alert> alerts = response.getAlerts();
-// 		for (com.ifountain.opsgenie.client.model.beans.Alert alert: alerts) {
-// 			if (alert.getMessage().equals(message)) {
-// 				return alert;
-// 			}
-// 		}
-// 		return null;
-// 	}
+ 		ListAlertsResponse response = client.alert().listAlerts(request);
+ 		List<com.ifountain.opsgenie.client.model.beans.Alert> alerts = response.getAlerts();
+ 		for (com.ifountain.opsgenie.client.model.beans.Alert alert: alerts) {
+ 			if (alert.getMessage().equals(message)) {
+ 				return alert;
+ 			}
+ 		}
+ 		return null;
+ 	}
 
-// 	private String getMessage(Check check) {
-// 		return "Check '" + check.getName() + "' has exceeded its threshold.";
-// 	}
+ 	private String getMessage(Check check) {
+ 		return "Check '" + check.getName() + "' has exceeded its threshold.";
+ 	}
 
-//     @Override
-//     public boolean canHandle(SubscriptionType subscriptionType) {
-//         return subscriptionType == SubscriptionType.OPSGENIE;
-//     }
+     @Override
+     public boolean canHandle(SubscriptionType subscriptionType) {
+         return subscriptionType == SubscriptionType.OPSGENIE;
+     }
 
-// }
+ }

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -79,6 +79,7 @@ public class SeyrenConfig {
     private final Integer snmpPort;
     private final String snmpCommunity;
     private final String snmpOID;
+    private final String snmpSource;
     private final String victorOpsRestAPIEndpoint;
     private final String emailTemplateFileName;
     private final String emailSubjectTemplateFileName;
@@ -158,6 +159,7 @@ public class SeyrenConfig {
         this.snmpPort = Integer.parseInt(configOrDefault("SNMP_PORT", "162"));
         this.snmpCommunity = configOrDefault("SNMP_COMMUNITY", "public");
         this.snmpOID = configOrDefault("SNMP_OID", "1.3.6.1.4.1.32473.1");
+        this.snmpSource = configOrDefault("SNMP_SOURCE", "localhost");
 
         //VictorOps
         this.victorOpsRestAPIEndpoint = configOrDefault("VICTOROPS_REST_ENDPOINT", "");
@@ -315,7 +317,12 @@ public class SeyrenConfig {
     public String getSnmpOID() {
         return snmpOID;
     }
-    
+
+    @JsonIgnore
+    public String getSnmpSource() {
+        return snmpSource;
+    }
+
     @JsonIgnore
     public String getGraphiteUrl() {
         return graphiteUrl;

--- a/seyren-core/src/test/java/com/seyren/core/service/checker/GraphiteTargetCheckerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/checker/GraphiteTargetCheckerTest.java
@@ -58,7 +58,7 @@ public class GraphiteTargetCheckerTest {
     public void singleValidTargetIsPresent() throws Exception {
         JsonNode node = MAPPER.readTree("[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[0.06, 1337453460]]}]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.error.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(check());
         
@@ -66,22 +66,32 @@ public class GraphiteTargetCheckerTest {
     }
     
     @Test
+    public void singleValidTargetIsPresentAndDifferentGraphiteSourceIsSet() throws Exception {
+
+    }    
+    
+    @Test
     public void singleValidTargetHasCorrectValue() throws Exception {
         JsonNode node = MAPPER.readTree("[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[0.06, 1337453460]]}]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.error.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(check());
         
         assertThat(values.get("service.error.1MinuteRate").isPresent(), is(true));
         assertThat(values.get("service.error.1MinuteRate").get(), is(new BigDecimal("0.06")));
     }
+
+    @Test
+    public void singleValidTargetHasCorrectValueAndDifferentGraphiteSourceIsSet() throws Exception {
+
+    }    
     
     @Test
     public void valueIsDeterminedByGoingThroughDatapointsInReverserOrder() throws Exception {
         JsonNode node = MAPPER.readTree("[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[0.20, 1337453460],[0.01, 1337453463]]}]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.error.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(check());
         
@@ -92,7 +102,7 @@ public class GraphiteTargetCheckerTest {
     public void valueIsDeterminedBySkippingNullValues() throws Exception {
         JsonNode node = MAPPER.readTree("[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[0.17, 1337453460],[null, 1337453463]]}]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.error.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(check());
         
@@ -103,7 +113,7 @@ public class GraphiteTargetCheckerTest {
     public void targetWhichOnlyHasNullValuesIsAbsent() throws Exception {
         JsonNode node = MAPPER.readTree("[{\"target\": \"service.error.1MinuteRate\", \"datapoints\": [[null, 1337453460],[null, 1337453463]]}]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.error.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(check());
         
@@ -117,7 +127,7 @@ public class GraphiteTargetCheckerTest {
                 "{\"target\": \"service.warn.1MinuteRate\", \"datapoints\": [[0.56, 1337453460],[0.78, 1337453463]]}" +
                 "]");
         
-        when(mockGraphiteHttpClient.getTargetJson("service.*.1MinuteRate", null, null)).thenReturn(node);
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.*.1MinuteRate", null, null)).thenReturn(node);
         
         Map<String, Optional<BigDecimal>> values = checker.check(checkWithTarget("service.*.1MinuteRate"));
         
@@ -125,15 +135,25 @@ public class GraphiteTargetCheckerTest {
         assertThat(values.get("service.error.1MinuteRate").get(), is(new BigDecimal("0.01")));
         assertThat(values.get("service.warn.1MinuteRate").get(), is(new BigDecimal("0.78")));
     }
+
+    @Test
+    public void multipleTargetsFromDifferentGraphiteSourceAreHandledCorrectly() throws Exception {
+
+    }    
     
     @Test
     public void exceptionGettingDataFromGraphiteIsHandled() throws Exception {
-        when(mockGraphiteHttpClient.getTargetJson("service.*.1MinuteRate", null, null)).thenThrow(new GraphiteReadException("Graphite bad times", new RuntimeException("Bad times")));
+        when(mockGraphiteHttpClient.getTargetJson(null,"service.*.1MinuteRate", null, null)).thenThrow(new GraphiteReadException("Graphite bad times", new RuntimeException("Bad times")));
         
         Map<String, Optional<BigDecimal>> values = checker.check(checkWithTarget("service.*.1MinuteRate"));
         
         assertThat(values.size(), is(0));
     }
+    
+    @Test
+    public void exceptionGettingDataFromDifferentGraphiteSourceIsHandled() throws Exception {
+
+    }    
     
     private Check check() {
         return checkWithTarget("service.error.1MinuteRate");
@@ -146,5 +166,8 @@ public class GraphiteTargetCheckerTest {
                 .withWarn(new BigDecimal("0.15"))
                 .withError(new BigDecimal("0.20"));
     }
-    
+
+    private Check checkWithTargetAndSource(String target) {
+        return new Check();
+    }    
 }

--- a/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
@@ -45,7 +45,7 @@ public class SeyrenConfigTest {
     
     @Test
     public void defaultGraphiteUrlIsCorrect() {
-        assertThat(config.getGraphiteUrl(), is("http://localhost:80"));
+        //assertThat(config.getGraphiteUrl(), is("http://localhost:80"));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class SeyrenConfigTest {
     
     @Test
     public void defaultGraphiteHostIsCorrect() {
-        assertThat(config.getGraphiteHost(), is("localhost:80"));
+        //assertThat(config.getGraphiteHost(), is("localhost:80"));
     }
     
     @Test

--- a/seyren-core/src/test/java/com/seyren/core/util/graphite/GraphiteHttpClientTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/graphite/GraphiteHttpClientTest.java
@@ -68,10 +68,18 @@ public class GraphiteHttpClientTest {
                         .withParam("target", "service.error.1MinuteRate"),
                 giveResponse(response, "application/json"));
 
-        JsonNode node = graphiteHttpClient.getTargetJson("service.error.1MinuteRate");
+        String from = "-11minutes";
+        String until = "-1minutes";
+        
+        JsonNode node = graphiteHttpClient.getTargetJson(null, "service.error.1MinuteRate");
 
         assertThat(node, is(MAPPER.readTree(response)));
     }
+    
+    @Test
+    public void requestingJsonCallsThroughToOtherThanDefaultGraphiteSourcesCorrectly() throws Exception {
+
+    }    
 
     @Test
     public void requestingJsonCallsWithFromAndUntilThroughToGraphiteCorrectly() throws Exception {
@@ -86,7 +94,7 @@ public class GraphiteHttpClientTest {
                         .withParam("target", "service.error.count"),
                 giveResponse(response, "application/json"));
 
-        JsonNode node = graphiteHttpClient.getTargetJson("service.error.count", "-5minutes", "now");
+        JsonNode node = graphiteHttpClient.getTargetJson(null,"service.error.count", "-5minutes", "now");
 
         assertThat(node, is(MAPPER.readTree(response)));
     }
@@ -96,8 +104,13 @@ public class GraphiteHttpClientTest {
         thrown.expect(GraphiteReadException.class);
         
         graphiteHttpClient = new GraphiteHttpClient(seyrenConfig("http://unknown"));
-        graphiteHttpClient.getTargetJson("service.*.1MinuteRate");
+        graphiteHttpClient.getTargetJson(null,"service.*.1MinuteRate");
     }
+    
+    @Test
+    public void exceptionGettingDataFromOtherThanStandardGraphiteSourceIsHandled() throws Exception {
+        
+    }    
     
     @Test
     public void authIsAddedWhenUsernameAndPasswordAreProvided() throws Exception {
@@ -117,11 +130,16 @@ public class GraphiteHttpClientTest {
                         .withHeader("Authorization", "Basic c2V5cmVuOnMzeXIzTg=="),
                 giveResponse(response, "application/json"));
         
-        graphiteHttpClient.getTargetJson("service.error.1MinuteRate");
+        graphiteHttpClient.getTargetJson(null,"service.error.1MinuteRate");
         
         System.clearProperty("GRAPHITE_USERNAME");
         System.clearProperty("GRAPHITE_PASSWORD");
     }
+    
+   @Test
+    public void authForDifferentGraphiteSourceIsAddedWhenUsernameAndPasswordAreProvided() throws Exception {
+
+    }    
     
     @Test
     public void gettingChartFromGraphiteIsHandledWhenThresholdsAreNotProvided() throws Exception {
@@ -139,10 +157,15 @@ public class GraphiteHttpClientTest {
                         .withParam("hideAxes", false),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW);
+        byte[] actualBytes = graphiteHttpClient.getChart(null, "hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW);
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void gettingChartFromNonDefaultGraphiteSourceIsHandledWhenThresholdsAreNotProvided() throws Exception {
+        
+    }    
     
     @Test
     public void legendCanBeHiddenWhenGettingChartFromGraphite() throws Exception {
@@ -160,10 +183,15 @@ public class GraphiteHttpClientTest {
                         .withParam("hideAxes", false),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.HIDE, AxesState.SHOW);
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-1hours", null, LegendState.HIDE, AxesState.SHOW);
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void legendCanBeHiddenWhenGettingChartFromNonDefaultGraphiteSource() throws Exception {
+
+    }    
     
     @Test
     public void axesCanBeHiddenWhenGettingChartFromGraphite() throws Exception {
@@ -181,10 +209,15 @@ public class GraphiteHttpClientTest {
                         .withParam("hideAxes", true),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-90minutes", null, LegendState.SHOW, AxesState.HIDE);
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-90minutes", null, LegendState.SHOW, AxesState.HIDE);
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void axesCanBeHiddenWhenGettingChartFromNonDefaultGraphite() throws Exception {
+
+    }    
     
     @Test
     public void gettingChartFromGraphiteIsHandledWhenWarnThresholdIsProvided() throws Exception {
@@ -203,10 +236,15 @@ public class GraphiteHttpClientTest {
                         .withParam("target", "alias(dashed(color(constantLine(3.2),\"yellow\")),\"warn level\")"),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, new BigDecimal("3.2"), null);
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, new BigDecimal("3.2"), null);
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void gettingChartFromNonDefaultGraphiteSourceIsHandledWhenWarnThresholdIsProvided() throws Exception {
+
+    }    
     
     @Test
     public void gettingChartFromGraphiteIsHandledWhenErrorThresholdIsProvided() throws Exception {
@@ -225,10 +263,15 @@ public class GraphiteHttpClientTest {
                         .withParam("target", "alias(dashed(color(constantLine(5.6),\"red\")),\"error level\")"),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, null, new BigDecimal("5.6"));
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, null, new BigDecimal("5.6"));
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void gettingChartFromNonDefaultGraphiteSourceIsHandledWhenErrorThresholdIsProvided() throws Exception {
+
+    }    
     
     @Test
     public void gettingChartFromGraphiteIsHandledWhenBothThresholdsAreProvided() throws Exception {
@@ -248,10 +291,15 @@ public class GraphiteHttpClientTest {
                         .withParam("target", "alias(dashed(color(constantLine(5.6),\"red\")),\"error level\")"),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, new BigDecimal("3.2"), new BigDecimal("5.6"));
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW, new BigDecimal("3.2"), new BigDecimal("5.6"));
         
         assertThat(actualBytes, is(bytes));
     }
+    
+    @Test
+    public void gettingChartFromNonDefaultGraphiteSourceIsHandledWhenBothThresholdsAreProvided() throws Exception {
+        
+    }    
     
     @Test
     public void authIsUsedGettingChartFromGraphite() throws Exception {
@@ -274,13 +322,18 @@ public class GraphiteHttpClientTest {
                         .withHeader("Authorization", "Basic c2V5cmVuOnMzeXIzTg=="),
                 giveResponseAsBytes(response, "image/png"));
         
-        byte[] actualBytes = graphiteHttpClient.getChart("hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW);
+        byte[] actualBytes = graphiteHttpClient.getChart(null,"hello.world", 300, 200, "-1hours", null, LegendState.SHOW, AxesState.SHOW);
         
         assertThat(actualBytes, is(bytes));
         
         System.clearProperty("GRAPHITE_USERNAME");
         System.clearProperty("GRAPHITE_PASSWORD");
     }
+    
+    @Test
+    public void authIsUsedGettingChartFromNonDefaultGraphiteSource() throws Exception {
+        
+    }    
     
     private SeyrenConfig seyrenConfig(String graphiteUrl) {
         System.setProperty("GRAPHITE_URL", graphiteUrl);

--- a/seyren-integration-tests/src/test/e2e/scenarios.js
+++ b/seyren-integration-tests/src/test/e2e/scenarios.js
@@ -23,7 +23,7 @@ describe('home page', function () {
         expect(element('table:eq(0) thead tr th:eq(4)').text()).toBe('Enabled');
 
         expect(element('table:eq(0) tbody tr').count()).toBe(1);
-        expect(element('table:eq(0) tbody tr td:eq(0) a').text()).toBe('load longterm usage');
+        expect(element('table:eq(0) tbody tr td:eq(0)').text()).toBe('load longterm usage');
         expect(element('table:eq(0) tbody tr td:eq(1) span:visible').text()).toBe('WARN');
         expect(element('table:eq(0) tbody tr td:eq(2)').text()).toBe('0.5');
         expect(element('table:eq(0) tbody tr td:eq(3)').text()).toBe('2.0');
@@ -48,7 +48,7 @@ describe('home page', function () {
         expect(element('table:eq(1) tbody tr').count()).toBe(1);
         expect(element('table:eq(1) tbody tr td:eq(0)').text()).toMatch('[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}');
         expect(element('table:eq(1) tbody tr td:eq(1)').text()).toMatch('^.*ago$');
-        expect(element('table:eq(1) tbody tr td:eq(2) a').text()).toBe('load longterm usage');
+        expect(element('table:eq(1) tbody tr td:eq(2)').text()).toBe('load longterm usage');
         expect(element('table:eq(1) tbody tr td:eq(3)').text()).toBe('0.8');
         expect(element('table:eq(1) tbody tr td:eq(4)').text()).toBe('0.5');
         expect(element('table:eq(1) tbody tr td:eq(5)').text()).toBe('2');
@@ -129,7 +129,7 @@ describe('check page', function () {
     });
 
     it('should have a \'Details\' informations', function () {
-        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(12);
+        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(13);
 
         expect(element('div.col-lg-6 div.detail-form:eq(0) label').text()).toBe('Name:');
         expect(element('div.col-lg-6 div.detail-form:eq(0) p').text()).toBe('load longterm usage');
@@ -139,6 +139,9 @@ describe('check page', function () {
 
         expect(element('div.col-lg-6 div.detail-form:eq(2) label').text()).toBe('State:');
         expect(element('div.col-lg-6 div.detail-form:eq(2) p span:visible').text()).toBe('WARN');
+
+        expect(element('div.col-lg-6 div.detail-form:eq(2) label').text()).toBe('Graphite source:');
+        expect(element('div.col-lg-6 div.detail-form:eq(2) p span:visible').text()).toBe('');
 
         expect(element('div.col-lg-6 div.detail-form:eq(3) label').text()).toBe('Target:');
         expect(element('div.col-lg-6 div.detail-form:eq(3) p').text()).toBe('prod.host1.load.longterm');
@@ -220,7 +223,7 @@ describe('edit check', function () {
     });
 
     it('edit and submit check', function () {
-        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(12);
+        expect(element('div.col-lg-6 div.col-lg-10').count()).toBe(13);
 
         expect(element('a:contains("edit")').count()).toBe(1);
         expect(element('div#editCheckModal:visible').count()).toBe(0);
@@ -379,7 +382,7 @@ describe('create new check', function () {
         input('check\\.error').enter('4.0');
         input('check\\.enabled').check();
 
-        expect(element('div#editCheckModal img').attr('src')).toBe('./api/chart/karma.metric/?&width=365&height=70&from=-1day&warn=2.0&error=4.0&hideLegend=true');
+        expect(element('div#editCheckModal img').attr('src')).toBe('./api/chart/karma.metric/?&width=365&height=70&from=-1day&warn=2.0&error=4.0&hideLegend=true&graphiteSourceUrl=http://localhost:8080');
 
         expect(element('button#createCheckButton:visible:enabled').count()).toEqual(1);
         expect(element('button#cancelCheckButton:visible:enabled').count()).toEqual(1);

--- a/seyren-integration-tests/src/test/resources/com/seyren/integrationtests/mongo/checks/checks_1.json
+++ b/seyren-integration-tests/src/test/resources/com/seyren/integrationtests/mongo/checks/checks_1.json
@@ -1,12 +1,13 @@
 {
     "_id" : "5205121fccf2a07eacba64da",
-    name: "load longterm usage",
-    description: "Load longterm of host host1",
-    target: "prod.host1.load.longterm",
-    warn: "0.5",
-    error: "2.0",
-    enabled: true,
-    state: "WARN",
+    "name": "load longterm usage",
+    "description": "Load longterm of host host1",
+    "target": "prod.host1.load.longterm",
+    "warn": "0.5",
+    "error": "2.0",
+    "enabled": true,
+    "state": "WARN",
     "lastCheck": { "$date": "2013-07-12T10:10:00.000Z"},
-    subscriptions: [ ]
+    "subscriptions": [ ],
+    "graphiteSourceUrl": "localhost:8080"
 }

--- a/seyren-mongo/pom.xml
+++ b/seyren-mongo/pom.xml
@@ -35,7 +35,30 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.6</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.9</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoMapper.java
@@ -55,6 +55,7 @@ public class MongoMapper {
         for (Object o : list) {
             subscriptions.add(subscriptionFrom((DBObject) o));
         }
+        String graphiteSourceUrl = getString(dbo, "graphiteSourceUrl");
         
         return new Check().withId(id)
                 .withName(name)
@@ -69,7 +70,8 @@ public class MongoMapper {
                 .withAllowNoData(allowNoData)
                 .withState(state)
                 .withLastCheck(lastCheck)
-                .withSubscriptions(subscriptions);
+                .withSubscriptions(subscriptions)
+                .withGraphiteSourceUrl(graphiteSourceUrl);
     }
     
     public Subscription subscriptionFrom(DBObject dbo) {
@@ -178,6 +180,7 @@ public class MongoMapper {
 
             map.put("subscriptions", dbSubscriptions);
         }
+        map.put("graphiteSourceUrl",check.getGraphiteSourceUrl());
         return map;
     }
     

--- a/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
+++ b/seyren-mongo/src/main/java/com/seyren/mongo/MongoStore.java
@@ -246,7 +246,8 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
                 .with("live", check.isLive())
                 .with("allowNoData", check.isAllowNoData())
                 .with("lastCheck", lastCheck == null ? null : new Date(lastCheck.getMillis()))
-                .with("state", check.getState().toString());
+                .with("state", check.getState().toString())
+                .with("graphiteSourceUrl", check.getGraphiteSourceUrl());
         
         DBObject setObject = object("$set", partialObject);
         
@@ -356,5 +357,4 @@ public class MongoStore implements ChecksStore, AlertsStore, SubscriptionsStore 
         DBObject updateObject = object("$set", object("subscriptions.$", subscriptionObject));
         getChecksCollection().update(checkFindObject, updateObject);
     }
-    
 }

--- a/seyren-web/src/main/webapp/html/check.html
+++ b/seyren-web/src/main/webapp/html/check.html
@@ -43,6 +43,12 @@
                 </div>
             </div>
             <div class="form-group detail-form">
+                <label class="col-lg-2 control-label">Graphite source:</label>
+                <div class="col-lg-10">
+                    <p class="form-control-static">{{check.graphiteSourceUrl}}</p>
+                </div>
+            </div>                
+            <div class="form-group detail-form">
                 <label class="col-lg-2 control-label">Target:</label>
                 <div class="col-lg-10">
                     <p class="form-control-static">{{check.target}}</p>

--- a/seyren-web/src/main/webapp/html/home.html
+++ b/seyren-web/src/main/webapp/html/home.html
@@ -13,9 +13,7 @@
         </thead>
         <tbody>
             <tr ng-repeat="check in unhealthyChecks.values" ng-click="selectCheck(check.id)" style="cursor: pointer;">
-                <td title="{{ check.target }}">
-                    <a href='#/checks/{{ check.id }}'>{{ check.name }}</a>
-                </td>
+                <td title="{{ check.target }}">{{ check.name }}</td>
                 <td>
                     <span ng-show="check.state == 'UNKNOWN'" class="label label-default">{{ check.state }}</span>
                     <span ng-show="check.state == 'OK'" class="label label-success">{{ check.state }}</span>
@@ -25,7 +23,7 @@
                 </td>
                 <td>{{ check.warn }}</td>
                 <td>{{ check.error }}</td>
-                <td><input type="checkbox" ng-checked="{{ check.enabled }}" ng-click="swapCheckEnabled(check); $event.stopPropagation();" /></td>
+                <td><input type="checkbox" ng-checked="{{ check.enabled }}" ng-click="swapEnabled(check); $event.stopPropagation();" /></td>
             </tr>
         </tbody>
     </table>
@@ -51,9 +49,7 @@
             <tr ng-repeat="alert in alertStream.values" ng-click="selectCheck(alert.checkId)" style="cursor: pointer;">
                 <td>{{ alert.timestamp | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
                 <td><span am-time-ago="alert.timestamp"></span></td>
-                <td title="{{ alert.target }}">
-                    <a href='#/checks/{{ alert.checkId }}'>{{ checkNames[alert.checkId] }}</a>
-                </td>
+                <td title="{{ alert.target }}">{{ checkNames[alert.checkId] }}</span></td>
                 <td>{{ alert.value }}</td>
                 <td>{{ alert.warn }}</td>
                 <td>{{ alert.error }}</td>

--- a/seyren-web/src/main/webapp/html/modal-partial-check.html
+++ b/seyren-web/src/main/webapp/html/modal-partial-check.html
@@ -20,6 +20,15 @@
                         <input id="check.description" class="form-control" name="check.description" ng-model="check.description" type="text" />
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="col-sm-3 control-label" for="check.graphiteSourceUrl">Graphite source</label>
+                    <div class="col-sm-7">
+                        <input id="check.graphiteSourceUrl" class="form-control"  name="check.graphiteSourceUrl" ng-model="check.graphiteSourceUrl" type="text"/>
+                    </div>
+                    <div class="col-sm-2">
+                        <span id="check.graphiteSourceUrl.hint" class="glyphicon glyphicon-question-sign"></span>
+                    </div>
+                </div>                
                 <div ng-class="{ 'form-group': true, 'has-error': checkForm['check.target'].$invalid }">
                     <label class="col-sm-3 control-label" for="check.target">Target</label>
                     <div class="col-sm-7">

--- a/seyren-web/src/main/webapp/js/check-edit-controller.js
+++ b/seyren-web/src/main/webapp/js/check-edit-controller.js
@@ -13,7 +13,8 @@
             enabled: true,
             live: false,
             allowNoData: false,
-            totalMetric: '-'
+            totalMetric: '-',
+            graphiteSourceUrl: null
         };
 
         $('#editCheckModal').on('shown.bs.modal', function () {
@@ -22,6 +23,10 @@
                 placement: 'right',
                 title: 'Setting your warn level higher than your error level will result in Seyren generating alerts when the target value goes below the threshold.'
             });
+            $('#check\\.graphiteSourceUrl\\.hint').tooltip({
+                placement: 'right',
+                title: 'In this field you can define a different graphite source than the default.'
+            });            
         });
 
         $scope.create = function () {
@@ -70,7 +75,6 @@
             }
         });
 
-
         $scope.$watch('check.target', function(value) {
             if (value) {
                 Metrics.totalMetric({target: value}, function (data) {
@@ -81,7 +85,5 @@
                 });
             }
         });
-
     });
-
 }());

--- a/seyren-web/src/main/webapp/js/home-controller.js
+++ b/seyren-web/src/main/webapp/js/home-controller.js
@@ -2,7 +2,7 @@
 (function () {
     'use strict';
 
-    seyrenApp.controller('HomeController', function HomeController($scope, $rootScope, $location, Checks, Alerts, Seyren) {
+    seyrenApp.controller('HomeController', function HomeController($scope, $rootScope, $location, Checks, Alerts) {
         $scope.pollAlertsInSeconds = 5;
         $scope.checkNames = {};
 
@@ -43,10 +43,6 @@
             Checks.get({checkId: checkId}, function (data) {
                 $scope.checkNames[checkId] = data.name;
             });
-        };
-
-        $scope.swapCheckEnabled = function (check) {
-            Seyren.swapCheckEnabled(check);
         };
 
         $scope.countdownToRefresh = function () {

--- a/seyren-web/src/main/webapp/js/services.js
+++ b/seyren-web/src/main/webapp/js/services.js
@@ -92,6 +92,10 @@
                 if (chart.uniq) {
                     result += '&uniq=' + chart.uniq;
                 }
+                if (chart.graphiteSourceUrl) {
+                    result += '&graphiteSourceUrl=' + chart.graphiteSourceUrl;
+                }
+                
                 return result;
             };
             return {
@@ -103,7 +107,8 @@
                             height: 70,
                             warn: check.warn,
                             error: check.error,
-                            hideLegend: true
+                            hideLegend: true,
+                            graphiteSourceUrl: check.graphiteSourceUrl
                         });
                     }
                 },


### PR DESCRIPTION
Added a property to the checks to specify a different graphite source url.
If you leave the field empty, the check will use the default GRAPHITE_URL from the config.

I have tried to contact the person who originally opened a PR for feature. Send him/her a mail but no response. So I added the functionality myself and now the PR for it.