### PR TITLE
Add option to use HipChat v1 API, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Use a [Flow API token](https://www.flowdock.com/account/tokens) as Target when a
 ##### [HipChat](https://www.hipchat.com)
 * `HIPCHAT_AUTHTOKEN` - The hipchat api auth token. Default: ``
 * `HIPCHAT_USERNAME` - The username that messages will be sent from. Default: `Seyren Alert`
+* `HIPCHAT_USE_V1_API` - Allow the use of HipChat's API for compatibility reasons. Default: `false`
 
 ##### [Hubot](http://hubot.github.com)
 * `HUBOT_URL` - The location where Hubot is running. Default ``

--- a/seyren-core/src/main/java/com/seyren/core/service/notification/HipChatNotificationService.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/notification/HipChatNotificationService.java
@@ -59,18 +59,17 @@ public class HipChatNotificationService implements NotificationService {
     public void sendNotification(Check check, Subscription subscription, List<Alert> alerts) throws NotificationFailedException {
         String token = seyrenConfig.getHipChatAuthToken();
         String from = seyrenConfig.getHipChatUsername();
-        boolean useV1Api = seyrenConfig.getHipChatUseV1Api();
         String[] roomIds = subscription.getTarget().split(",");
         try {
             if (check.getState() == AlertType.ERROR) {
                 String message = getHipChatMessage(check);
-                sendMessage(message, MessageColor.RED, roomIds, from, token, useV1Api, true);
+                sendMessage(message, MessageColor.RED, roomIds, from, token, true);
             } else if (check.getState() == AlertType.WARN) {
                 String message = getHipChatMessage(check);
-                sendMessage(message, MessageColor.YELLOW, roomIds, from, token, useV1Api, true);
+                sendMessage(message, MessageColor.YELLOW, roomIds, from, token, true);
             } else if (check.getState() == AlertType.OK) {
                 String message = getHipChatMessage(check);
-                sendMessage(message, MessageColor.GREEN, roomIds, from, token, useV1Api, true);
+                sendMessage(message, MessageColor.GREEN, roomIds, from, token, true);
             } else {
                 LOGGER.warn("Did not send notification to HipChat for check in state: {}", check.getState());
             }
@@ -84,7 +83,8 @@ public class HipChatNotificationService implements NotificationService {
         return message;
     }
     
-    private void sendMessage(String message, MessageColor color, String[] roomIds, String from, String authToken, boolean useV1Api, boolean notify) {
+    private void sendMessage(String message, MessageColor color, String[] roomIds, String from, String authToken, boolean notify) {
+        boolean useV1Api = seyrenConfig.getHipChatUseV1Api();
         for (String roomId : roomIds) {
             LOGGER.info("Posting: {} to {}: {} {}", from, roomId, message, color);
             HttpClient client = HttpClientBuilder.create().useSystemProperties().build();

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -56,6 +56,7 @@ public class SeyrenConfig {
     private final String hipChatBaseUrl;
     private final String hipChatAuthToken;
     private final String hipChatUsername;
+    private final String hipChatUseV1Api;
     private final String hubotUrl;
     private final String smtpFrom;
     private final String smtpUsername;
@@ -122,6 +123,7 @@ public class SeyrenConfig {
         this.hipChatBaseUrl = configOrDefault(list("HIPCHAT_BASEURL", "HIPCHAT_BASE_URL"), "https://api.hipchat.com");
         this.hipChatAuthToken = configOrDefault(list("HIPCHAT_AUTHTOKEN", "HIPCHAT_AUTH_TOKEN"), "");
         this.hipChatUsername = configOrDefault(list("HIPCHAT_USERNAME", "HIPCHAT_USER_NAME"), "Seyren Alert");
+        this.hipChatUseV1Api = configOrDefault(list("HIPCHAT_USE_V1_API", "HIPCHAT_USE_OLD_API", "HIPCHAT_USE_V1"), "false");
         
         // PagerDuty
 
@@ -235,6 +237,11 @@ public class SeyrenConfig {
     @JsonIgnore
     public String getHipChatUsername() {
         return hipChatUsername;
+    }
+
+    @JsonIgnore
+    public boolean getHipChatUseV1Api() {
+        return Boolean.valueOf(hipChatUseV1Api);
     }
     
     @JsonIgnore

--- a/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/util/config/SeyrenConfigTest.java
@@ -132,7 +132,7 @@ public class SeyrenConfigTest {
     public void defaultHipChatUsernameIsCorrect() {
         assertThat(config.getHipChatUsername(), is("Seyren Alert"));
     }
-    
+
     @Test
     public void defaultHubotUrlIsCorrect() {
         assertThat(config.getHubotUrl(), is(""));


### PR DESCRIPTION
Recently we ran into an issue where most of our HipChat integrations are still using the V1 API.  V2 API also requires an admin token to post into multiple rooms at once, which we did not want to provide.

I added the `HIPCHAT_USE_V1_API` environment setting, which forces a request to be made to HipChat via V1 REST API using the token specified.