### PR TITLE
Fixing hyper link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Seyren ([/ˈsaɪ.rʌn/](http://en.wikipedia.org/wiki/Wikipedia:IPA_for_English#K
 ### Prerequisites
 
 * An instance of Graphite
-* MongoDB ([Install instructions](http://docs.mongodb.org/manual/installation/#installation-guides Installing MongoDB))
+* MongoDB [Install instructions](http://docs.mongodb.org/manual/installation/#installation-guides)
 
 ### Run
 


### PR DESCRIPTION
The mongo db installation instructions are rendering as

    MongoDB ([Install instructions](http://docs.mongodb.org/manual/installation/#installation-guides Installing MongoDB))