### PR TITLE
fixing opsgenie maven deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <com.fasterxml.jackson.jaxrs.version>2.5.0</com.fasterxml.jackson.jaxrs.version>
         <com.github.rest-driver.version>1.1.42</com.github.rest-driver.version>
         <com.google.guava.version>18.0</com.google.guava.version>
-        <com.opsgenie.integration.sdk.version>2.0.7</com.opsgenie.integration.sdk.version>
+        <com.opsgenie.integration.sdk.version>[2.0.0,)</com.opsgenie.integration.sdk.version>
         <com.squareup.pagerduty.version>1.0.1</com.squareup.pagerduty.version>
         <commons.io.version>2.4</commons.io.version>
         <commons-lang.version>2.6</commons-lang.version>

--- a/seyren-core/pom.xml
+++ b/seyren-core/pom.xml
@@ -109,12 +109,4 @@
         	<artifactId>sdk</artifactId>
     	</dependency>
     </dependencies>
-	<repositories>
-	  <repository>
-	      <id>opsgenie-repo</id>
-	      <name>OpsGenie Maven Repository</name>
-	      <url>http://repo.opsgenie.com:9393/content/groups/public</url>
-	      <layout>default</layout>
-	  </repository>
-	</repositories>
 </project>


### PR DESCRIPTION
Breaks at the step:
```Downloading: http://repo.opsgenie.com:9393/content/groups/public/com/opsgenie/integration/sdk/2.0.7/sdk-2.0.7.pom```
because `http://repo.opsgenie.com:9393/` does not exist anymore.

Fixing this by following the matching the docs here:
https://docs.opsgenie.com/docs/maven-and-gradle